### PR TITLE
fix: sweep against the base's upstream, and stop hiding the branch you're on (#76)

### DIFF
--- a/bin/csw-sweep
+++ b/bin/csw-sweep
@@ -41,7 +41,9 @@ usage() {
 Usage:
   csw-sweep            Human-readable report of stale branches and worktrees
   csw-sweep branches   One stale local branch per line
-  csw-sweep worktrees  <path><TAB><branch> per line for worktrees holding one
+  csw-sweep worktrees  <path><TAB><branch> per line for linked worktrees holding
+                       one. The main working tree is never listed -- git refuses
+                       to remove it -- but its branch still appears in branches.
 EOF
 }
 
@@ -61,9 +63,12 @@ merged_into() { # commit-ish
   git for-each-ref --format='%(refname:short)' --merged "$1" refs/heads 2>/dev/null || true
 }
 
+current_branch() {
+  git branch --show-current 2>/dev/null || true
+}
+
 stale_branches() {
-  local current merged gone upstream
-  current=$(git branch --show-current 2>/dev/null || true)
+  local merged gone upstream
   # Merged into the base. Requires --merge merges; squash-merges are invisible here.
   merged=$(merged_into "$BASE")
   # ...and merged into the base's upstream. On a machine where PRs are merged on
@@ -79,11 +84,24 @@ stale_branches() {
   # Upstream deleted — what `gh pr merge --delete-branch` leaves behind.
   gone=$(git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads 2>/dev/null \
     | awk '$2 == "[gone]" { print $1 }')
+  # The base itself is excluded -- it is the thing everything else is measured
+  # against, never a leftover. -F because a base branch name is a literal, not a
+  # pattern: an unescaped `.` in `release/1.x` would otherwise match unrelated
+  # branch names and silently drop them from the sweep.
+  #
+  # The *current* branch is deliberately NOT excluded. It used to be, which
+  # hid the single branch a human is most likely to care about: standing on a
+  # branch that has already shipped, the sweep said nothing at all. Inside
+  # csw:cleanup that exclusion was invisible -- Steps 2-3 delete that branch
+  # before the sweep in Step 4 ever runs -- but standalone it made the tool
+  # silent about the obvious. Reporting it means a name in this output is no
+  # longer guaranteed to be deletable with `git branch -d` from where the
+  # caller stands; git refuses that loudly and harmlessly, and a caller that
+  # wants it gone has to land on the base branch first either way.
   printf '%s\n%s\n' "$merged" "$gone" \
     | sed -e '/^$/d' \
     | sort -u \
     | grep -Fvx "$BASE" \
-    | grep -Fvx "${current:-@@no-current-branch@@}" \
     || true
 }
 
@@ -102,10 +120,28 @@ base_behind_note() {
     "$BASE" "$count" "$upstream"
 }
 
+# The main working tree's root, or empty if it cannot be determined. Used to
+# keep it out of the `worktrees` output: `git worktree remove` refuses the main
+# working tree outright, so listing it offers the caller an action that cannot
+# succeed. Its branch still shows up in `branches`, which is the actionable
+# signal -- land on the base branch, then delete.
+main_worktree() {
+  local common
+  common=$(git rev-parse --git-common-dir 2>/dev/null || true)
+  [ -n "$common" ] || return 0
+  # --git-common-dir may be relative (plain `.git`) or absolute depending on
+  # where it is run from; resolving through `cd` handles both, and -P matches
+  # the fully-resolved paths `git worktree list` prints. If it cannot be
+  # resolved, print nothing and let every worktree through -- degrading to the
+  # old, noisier behaviour beats dropping a real worktree from the sweep.
+  (cd "$common/.." 2>/dev/null && pwd -P) || true
+}
+
 stale_worktrees() {
-  local stale path ref short
+  local stale path ref short main
   stale=$(stale_branches)
   if [ -z "$stale" ]; then return 0; fi
+  main=$(main_worktree)
   # Hand path/ref pairs from awk to the read loop NUL-delimited, not
   # TAB-delimited: a worktree path is free to contain a literal TAB (rare,
   # but git allows it), and splitting on TAB would silently mis-parse such a
@@ -120,6 +156,7 @@ stale_worktrees() {
     END           { if (path != "") printf "%s%c%s%c", path, 0, ref, 0 }
   ' | while IFS= read -r -d '' path && IFS= read -r -d '' ref; do
     if [ -z "$ref" ]; then continue; fi
+    if [ -n "$main" ] && [ "$path" = "$main" ]; then continue; fi
     # The output contract is <path><TAB><branch>, one worktree per line, so a
     # line-oriented consumer can split each line on its first TAB. A path
     # that itself contains a TAB -- or a newline, which would break
@@ -169,7 +206,18 @@ case "${1:-}" in
     fi
     if [ -n "$b" ]; then
       printf 'Merged or upstream-gone branches:\n'
-      printf '%s\n' "$b" | sed -e 's/^/  /'
+      # Annotate the branch the caller is standing on. It is in the list like
+      # any other, but it is the one entry `git branch -d` will refuse from
+      # here, so the report says what to do about it rather than leaving the
+      # reader to decode git's error.
+      cur=$(current_branch)
+      printf '%s\n' "$b" | while IFS= read -r name; do
+        if [ -n "$cur" ] && [ "$name" = "$cur" ]; then
+          printf '  %s  (current branch — check out %s first, then delete)\n' "$name" "$BASE"
+        else
+          printf '  %s\n' "$name"
+        fi
+      done
     fi
     ;;
   -h|--help)

--- a/bin/csw-sweep
+++ b/bin/csw-sweep
@@ -45,14 +45,37 @@ Usage:
 EOF
 }
 
+# The base branch's upstream, e.g. `origin/main`, or empty when the base has no
+# upstream configured (or does not resolve at all). Reads only what the
+# remote-tracking ref already knows: csw-sweep is a reporting tool and must
+# never fetch, so it neither mutates refs nor touches the network.
+base_upstream() {
+  git rev-parse --abbrev-ref "$BASE@{upstream}" 2>/dev/null || true
+}
+
+# Local branches fully merged into <commit-ish>.
+# Plumbing, not `git branch --merged`: the porcelain command emits a synthetic
+# "(HEAD detached at ...)" pseudo-entry when HEAD is detached, which is not a
+# branch name and must never reach the output. for-each-ref only walks real refs.
+merged_into() { # commit-ish
+  git for-each-ref --format='%(refname:short)' --merged "$1" refs/heads 2>/dev/null || true
+}
+
 stale_branches() {
-  local current merged gone
+  local current merged gone upstream
   current=$(git branch --show-current 2>/dev/null || true)
   # Merged into the base. Requires --merge merges; squash-merges are invisible here.
-  # Plumbing, not `git branch --merged`: the porcelain command emits a synthetic
-  # "(HEAD detached at ...)" pseudo-entry when HEAD is detached, which is not a
-  # branch name and must never reach the output. for-each-ref only walks real refs.
-  merged=$(git for-each-ref --format='%(refname:short)' --merged "$BASE" refs/heads 2>/dev/null || true)
+  merged=$(merged_into "$BASE")
+  # ...and merged into the base's upstream. On a machine where PRs are merged on
+  # the forge rather than locally — this workflow's whole premise — the local
+  # base is routinely behind, and a branch that genuinely shipped is not merged
+  # into it. Checking only the local base makes exactly the branches this tool
+  # exists to find invisible. Union rather than replace: the local base can
+  # legitimately carry merges the upstream has not seen yet.
+  upstream=$(base_upstream)
+  if [ -n "$upstream" ]; then
+    merged=$(printf '%s\n%s\n' "$merged" "$(merged_into "$upstream")")
+  fi
   # Upstream deleted — what `gh pr merge --delete-branch` leaves behind.
   gone=$(git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads 2>/dev/null \
     | awk '$2 == "[gone]" { print $1 }')
@@ -62,6 +85,21 @@ stale_branches() {
     | grep -Fvx "$BASE" \
     | grep -Fvx "${current:-@@no-current-branch@@}" \
     || true
+}
+
+# A silent sweep and a stale one look identical from the outside, and the report
+# is the only place a human is reading prose. Say when the local base is behind
+# its upstream, so "nothing to sweep" can be read as an answer rather than as a
+# possibly-stale one. Prints nothing when the base has no upstream, when the
+# comparison cannot be made, or when the base is level with or ahead of it.
+base_behind_note() {
+  local upstream count
+  upstream=$(base_upstream)
+  [ -n "$upstream" ] || return 0
+  count=$(git rev-list --count "$BASE..$upstream" 2>/dev/null || true)
+  [ -n "$count" ] && [ "$count" != "0" ] || return 0
+  printf 'note: local %s is %s commit(s) behind %s (not fetched); swept against both\n' \
+    "$BASE" "$count" "$upstream"
 }
 
 stale_worktrees() {
@@ -118,6 +156,9 @@ case "${1:-}" in
   ''|report)
     b=$(stale_branches)
     w=$(stale_worktrees)
+    # Before the findings, and before "nothing to sweep" — the caveat has to
+    # reach the reader whether or not anything was found.
+    base_behind_note
     if [ -z "$b" ] && [ -z "$w" ]; then
       printf 'nothing to sweep\n'
       exit 0

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -136,6 +136,42 @@ A stale worktree that `csw-sweep` lists but `git worktree remove` refuses to del
 known rough edge at the worktree-plus-shipped intersection. Report it plainly rather than
 forcing it.
 
+### The branch you are standing on
+
+The sweep reports a merged branch even when it is the one currently checked out, marking it
+`(current branch — check out <base> first, then delete)`. On the normal chained path this
+never fires: Steps 2–3 already landed on the base branch and deleted the branch this run was
+about. It fires when cleanup is invoked in a plain checkout that is simply sitting on work
+that already shipped.
+
+`git branch -d` refuses the checked-out branch, so — once it is approved along with the rest
+of the sweep — land first, then delete:
+
+```bash
+git checkout "<baseBranch>"
+git pull
+git branch -d "<the current branch the sweep flagged>"
+```
+
+That is the same land-then-delete Step 2 and Step 3 do, applied to a branch this run did not
+open. The approval rule above is unchanged: it is still swept work, so it is still proposed
+and waited on, never deleted on sight.
+
+## Step 4a: End on the base branch
+
+Cleanup finishes on the base branch, current with its remote, with nothing merged left lying
+around. That is the whole point of the exercise — the next piece of work starts from a clean
+checkout in a fresh session, with no leftovers to trip over. Before moving to the tracker:
+
+```bash
+git branch --show-current      # must be <baseBranch>
+git status -sb                 # must be clean, and not behind
+```
+
+If either says otherwise, say so explicitly rather than letting the session end somewhere
+unexpected. Being left on a deleted branch's detached HEAD, or on a base branch three commits
+behind its remote, is exactly the state that silently backdates the next branch cut from it.
+
 ## Step 5: The tracker, last
 
 Report the ticket's current state. If the PR body said `Closes <TICKET>`, the tracker may
@@ -163,6 +199,9 @@ is clean, even when it is obvious. Propose it, name what you would set it to, an
 | "The ticket is clearly done, I'll close it" | Always ask. Every time. |
 | "The sweep is empty, nothing to report" | Report the empty sweep. Silence reads as "not checked". |
 | "`csw-sweep` printed nothing, so there's nothing stale" | Check the exit code. Non-zero means the sweep did not run — unknown is not the same as absent. |
+| "The sweep flagged the branch I'm on, so it must be confused" | It is not. Land on the base branch, then delete it. Standing on shipped work is the ordinary case, not an anomaly. |
+| "`git branch -d` refused the current branch, so I'll leave it" | Refusing the *checked-out* branch is not the unmerged-commits refusal. Check out the base first, then delete. |
+| "Cleanup is done, wherever the checkout happens to be" | It ends on the base branch, current with its remote. Anything else backdates the next branch cut from it. |
 | "That other worktree is obviously stale too" | List it, ask, then act. |
 | "`git branch -d` refused, I'll use -D" | Refusal means unmerged commits. Investigate. |
 | "Uncommitted changes in the worktree are just scratch" | Show them first. That call is not yours. |

--- a/tests/test-csw-sweep.sh
+++ b/tests/test-csw-sweep.sh
@@ -221,4 +221,139 @@ case "$wtdot_worktrees" in
   *) PASSES=$((PASSES + 1)) ;;
 esac
 
+# --- The local base branch is behind its upstream -----------------------------
+#
+# The normal state on a machine where PRs are merged on the forge rather than
+# locally: `main` is stale, so a branch that genuinely shipped is not merged
+# into the *local* base and used to be invisible to the sweep entirely.
+#
+# make_upstream_clone prints the path of a fresh clone of an origin whose
+# `main` carries a `--no-ff` merge of `feat/already-merged` plus a later
+# commit. In the clone: `feat/already-merged` exists as a local branch with no
+# upstream of its own (so the `[gone]` path cannot be what reports it), an
+# unrelated `feat/never-merged` exists, and local `main` is reset back to the
+# pre-merge commit — three commits behind `origin/main`.
+make_upstream_clone() {
+  local origin base0 parent clone
+  origin=$(make_repo)
+  base0=$(git -C "$origin" rev-parse HEAD)
+  (
+    cd "$origin" || exit 1
+    git checkout -q -b feat/already-merged
+    printf 'm\n' >m.txt
+    git add -A && git commit -qm "work that shipped via a PR"
+    git checkout -q main
+    git merge -q --no-ff -m "merge feat/already-merged" feat/already-merged
+    printf 'more\n' >more.txt
+    git add -A && git commit -qm "later work on main"
+  ) || return 1
+  parent=$(mktemp -d)
+  TMPDIRS+=("$parent")
+  clone="$parent/work"
+  git clone -q "$origin" "$clone" || return 1
+  write_config "$clone" <<'JSON'
+{ "baseBranch": "main", "worktreeDir": ".claude/worktrees" }
+JSON
+  (
+    cd "$clone" || exit 1
+    git config user.email test@example.com
+    git config user.name "CSW Test"
+    git config commit.gpgsign false
+    # --no-track: this branch must have no upstream, so `[gone]` cannot be the
+    # reason it gets swept. Only the upstream-merged union can report it.
+    git branch --no-track feat/already-merged origin/feat/already-merged
+    git checkout -q -b feat/never-merged
+    printf 'n\n' >n.txt
+    git add -A && git commit -qm "work still in flight"
+    git checkout -q main
+    git reset -q --hard "$base0"
+  ) || return 1
+  printf '%s\n' "$clone"
+}
+
+behind=$(make_upstream_clone) || behind=""
+if [ -z "$behind" ]; then
+  FAILURES=$((FAILURES + 1))
+  printf 'FAIL could not build the behind-upstream fixture\n' >&2
+else
+  git -C "$behind" worktree add -q "$behind/.claude/worktrees/shipped" feat/already-merged
+
+  behind_branches=$(cd "$behind" && "$BIN/csw-sweep" branches)
+  assert_contains "$behind_branches" "feat/already-merged" \
+    "a branch merged into origin/<base> but not local <base> is swept"
+  case "$behind_branches" in
+    *feat/never-merged*)
+      assert_eq "unmerged-listed" "not-listed" \
+        "a branch merged into neither local nor upstream base is not swept" ;;
+    *) PASSES=$((PASSES + 1)) ;;
+  esac
+  case "$behind_branches" in
+    *main*)
+      assert_eq "base-listed" "not-listed" \
+        "the base branch is not swept just because it is an ancestor of its upstream" ;;
+    *) PASSES=$((PASSES + 1)) ;;
+  esac
+
+  behind_worktrees=$(cd "$behind" && "$BIN/csw-sweep" worktrees)
+  assert_contains "$behind_worktrees" "worktrees/shipped" \
+    "a worktree holding a branch merged only upstream is swept too"
+
+  # A stale local base must be visible in the report, so a silent answer is
+  # distinguishable from a stale one.
+  behind_report=$(cd "$behind" && "$BIN/csw-sweep")
+  assert_contains "$behind_report" "behind" "the report says the local base is behind"
+  assert_contains "$behind_report" "origin/main" "the report names the upstream it is behind"
+
+  # Read-only: reporting must not fetch, move refs, or touch the working tree.
+  before=$(cd "$behind" && git for-each-ref --format='%(refname) %(objectname)' | sort)
+  (cd "$behind" && "$BIN/csw-sweep" >/dev/null)
+  after=$(cd "$behind" && git for-each-ref --format='%(refname) %(objectname)' | sort)
+  assert_eq "$after" "$before" "the sweep does not move any ref"
+fi
+
+# No upstream configured on the base: behave exactly as before the fix — the
+# upstream-merged branch is invisible, and no staleness note is emitted.
+noup=$(make_upstream_clone) || noup=""
+if [ -z "$noup" ]; then
+  FAILURES=$((FAILURES + 1))
+  printf 'FAIL could not build the no-upstream fixture\n' >&2
+else
+  git -C "$noup" branch --unset-upstream main
+  noup_branches=$(cd "$noup" && "$BIN/csw-sweep" branches)
+  case "$noup_branches" in
+    *feat/already-merged*)
+      assert_eq "swept-without-upstream" "not-swept" \
+        "with no upstream on the base, the upstream-merged branch stays invisible" ;;
+    *) PASSES=$((PASSES + 1)) ;;
+  esac
+  noup_report=$(cd "$noup" && "$BIN/csw-sweep")
+  assert_contains "$noup_report" "nothing to sweep" \
+    "with no upstream on the base, the report is unchanged"
+  case "$noup_report" in
+    *behind*)
+      assert_eq "note-without-upstream" "no-note" \
+        "no upstream means no staleness note" ;;
+    *) PASSES=$((PASSES + 1)) ;;
+  esac
+fi
+
+# Base level with its upstream: the branch is swept via the local base as it
+# always was, and the staleness note must not fire spuriously.
+level=$(make_upstream_clone) || level=""
+if [ -z "$level" ]; then
+  FAILURES=$((FAILURES + 1))
+  printf 'FAIL could not build the level-with-upstream fixture\n' >&2
+else
+  git -C "$level" merge -q --ff-only origin/main
+  level_report=$(cd "$level" && "$BIN/csw-sweep")
+  assert_contains "$level_report" "feat/already-merged" \
+    "an up-to-date base still sweeps its merged branches"
+  case "$level_report" in
+    *behind*)
+      assert_eq "note-when-level" "no-note" \
+        "a base level with its upstream produces no staleness note" ;;
+    *) PASSES=$((PASSES + 1)) ;;
+  esac
+fi
+
 report

--- a/tests/test-csw-sweep.sh
+++ b/tests/test-csw-sweep.sh
@@ -31,11 +31,22 @@ case "$branches" in
   *) PASSES=$((PASSES + 1)) ;;
 esac
 
-# The current branch is never swept, even when it is merged.
+# The current branch IS swept when it is merged. Standing on a branch that has
+# already shipped is the single case a human is most likely to care about, and
+# hiding it made the sweep silent about the obvious.
 git checkout -q feat/merged
-assert_eq "$("$BIN/csw-sweep" branches | grep -c 'feat/merged' || true)" "0" \
-  "current branch is never swept"
+assert_eq "$("$BIN/csw-sweep" branches | grep -c '^feat/merged$' || true)" "1" \
+  "a merged current branch is swept, not hidden"
+# ...and the report says what to do about it, since `git branch -d` refuses the
+# checked-out branch.
+cur_report=$("$BIN/csw-sweep")
+assert_contains "$cur_report" "current branch" "the report flags the current branch"
+assert_contains "$cur_report" "check out main first" \
+  "the report says to land on the base branch before deleting it"
+# The base branch is still never swept, even while standing on it.
 git checkout -q main
+assert_eq "$("$BIN/csw-sweep" branches | grep -c '^main$' || true)" "0" \
+  "the base branch is never swept, even as the current branch"
 
 # A worktree holding a merged branch shows up; one holding unmerged work does not.
 git worktree add -q "$repo/.claude/worktrees/merged" feat/merged
@@ -46,38 +57,61 @@ assert_contains "$worktrees" "worktrees/merged" "worktree on a merged branch is 
 assert_eq "$(printf '%s' "$worktrees" | grep -c . || true)" "1" \
   "only the merged worktree is swept"
 
+# The main working tree is never listed as a stale worktree, even when it holds
+# a merged branch: `git worktree remove` refuses it outright, so listing it
+# offers an action that cannot succeed. The branch itself still reports.
+mainwt=$(make_repo)
+write_config "$mainwt" <<'JSON'
+{ "baseBranch": "main", "worktreeDir": ".claude/worktrees" }
+JSON
+(
+  cd "$mainwt" || exit 1
+  git checkout -q -b feat/shipped
+  printf 's\n' >s.txt
+  git add -A && git commit -qm "shipped work"
+  git checkout -q main
+  git merge -q --no-ff -m "merge feat/shipped" feat/shipped
+  git checkout -q feat/shipped
+)
+assert_contains "$(cd "$mainwt" && "$BIN/csw-sweep" branches)" "feat/shipped" \
+  "a merged branch held by the main working tree still reports as a branch"
+assert_eq "$(cd "$mainwt" && "$BIN/csw-sweep" worktrees)" "" \
+  "the main working tree is never listed as a removable stale worktree"
+
 # A clean repo sweeps to nothing, and still exits 0.
 clean=$(make_repo)
 assert_eq "$(cd "$clean" && "$BIN/csw-sweep" branches)" "" "clean repo has no branches to sweep"
 assert_contains "$(cd "$clean" && "$BIN/csw-sweep")" "nothing to sweep" "clean repo reports nothing to sweep"
 assert_status 0 "clean sweep exits 0" -- in_dir "$clean" "$BIN/csw-sweep"
 
-# A `.` in the current branch name must not act as a regex wildcard and
-# swallow an unrelated merged branch (feat/a.b as current used to hide
-# feat/aXb, because grep -vx treated the current branch as a pattern).
+# A `.` in the BASE branch name must not act as a regex wildcard and swallow an
+# unrelated merged branch: `release/1.x` as a BRE pattern also matches
+# `release/1Xx`, which would silently drop a genuinely stale branch from the
+# sweep. This is what keeps the `grep -Fvx "$BASE"` filter honest. (The same
+# hazard used to exist on a current-branch filter, which no longer exists —
+# a merged current branch is now reported like any other.)
 dotrepo=$(make_repo)
 write_config "$dotrepo" <<'JSON'
-{ "baseBranch": "main", "worktreeDir": ".claude/worktrees" }
+{ "baseBranch": "release/1.x", "worktreeDir": ".claude/worktrees" }
 JSON
 (
   cd "$dotrepo" || exit 1
-  git checkout -q -b feat/a.b
-  printf 'ab\n' >ab.txt
-  git add -A && git commit -qm "a.b work"
-  git checkout -q main
-  git merge -q --no-ff -m "merge feat/a.b" feat/a.b
-
-  git checkout -q -b feat/aXb
+  git checkout -q -b "release/1.x"
+  git checkout -q -b "release/1Xx"
   printf 'axb\n' >axb.txt
-  git add -A && git commit -qm "aXb work"
-  git checkout -q main
-  git merge -q --no-ff -m "merge feat/aXb" feat/aXb
-
-  git checkout -q feat/a.b
+  git add -A && git commit -qm "1Xx work"
+  git checkout -q "release/1.x"
+  git merge -q --no-ff -m "merge release/1Xx" "release/1Xx"
 )
 dot_branches=$(cd "$dotrepo" && "$BIN/csw-sweep" branches)
-assert_contains "$dot_branches" "feat/aXb" \
-  "a dot in the current branch name does not swallow an unrelated merged branch"
+assert_contains "$dot_branches" "release/1Xx" \
+  "a dot in the base branch name does not swallow an unrelated merged branch"
+case "$dot_branches" in
+  *"release/1.x"*)
+    assert_eq "dotted-base-swept" "not-swept" \
+      "a base branch containing a dot is still never swept" ;;
+  *) PASSES=$((PASSES + 1)) ;;
+esac
 
 # A branch name with a `+` (also special to regexes) round-trips correctly
 # through both `branches` and `worktrees`.

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -137,6 +137,17 @@ assert_contains "$(cat "$cleanup")" "unknown, not absent" "cleanup: a failed swe
 assert_contains "$(cat "$cleanup")" "the command failing for any reason" "cleanup: any gh pr view failure is a stop, not just a non-merged state"
 assert_contains "$(cat "$cleanup")" "already gone" \
   "cleanup: Step 3 treats a worktree ExitWorktree already removed as success, not failure"
+# The sweep now reports a merged branch even when it is checked out, which
+# `git branch -d` refuses. Cleanup has to know to land on the base first.
+assert_contains "$(cat "$cleanup")" "The branch you are standing on" \
+  "cleanup: handles a swept branch that is the current branch"
+assert_contains "$(cat "$cleanup")" "refuses the checked-out branch" \
+  "cleanup: names why the current branch needs landing first, not -D"
+# Cleanup exists to leave a clean checkout behind for the next session.
+assert_contains "$(cat "$cleanup")" "End on the base branch" \
+  "cleanup: states its end state explicitly"
+assert_contains "$(cat "$cleanup")" "git branch --show-current      # must be" \
+  "cleanup: verifies where it landed rather than assuming"
 
 # --- batch: never auto-invoked, always explains its skips ---
 batch="$SKILLS/batch/SKILL.md"


### PR DESCRIPTION
Two related ways `bin/csw-sweep` stayed silent about branches that had already shipped. Both surfaced dogfooding against `~/mikestankavich.com`.

## 1. Merged upstream, but not into the local base (#76 as filed)

The merged set was computed against the **local** base branch only. On a machine where PRs are merged on the forge rather than locally — this workflow's whole premise — the local base is routinely behind, so a branch that genuinely shipped is not merged into it and was invisible.

- `stale_branches` now unions the set merged into `<base>` with the set merged into `<base>@{upstream}`, when an upstream exists. Union, not replace: the local base can legitimately carry merges the upstream has not seen yet.
- Reads only the remote-tracking ref already on disk — **no fetch**, no ref mutation, no network. A test asserts no ref moves across a sweep.
- Because that ref may itself be stale, the report leads with `note: local main is 3 commit(s) behind origin/main (not fetched); swept against both`, printed before the findings *and* before `nothing to sweep`.
- With no upstream on the base, behaviour is exactly what it was.

## 2. The branch you are standing on

The sweep filtered out the current branch unconditionally — hiding the single branch a human is most likely to care about. Inside `csw:cleanup` that exclusion was invisible (Steps 2–3 delete that branch before Step 4 sweeps), but standalone it made the tool silent about the obvious.

- Report it like any other, annotated `(current branch — check out main first, then delete)`, since `git branch -d` refuses the checked-out branch.
- **Contract change:** a name in `csw-sweep branches` is no longer guaranteed deletable with `git branch -d` from where the caller stands. Git refuses that loudly and harmlessly, which beats a silent omission.
- Conversely, the **main working tree** is no longer listed under `worktrees` — `git worktree remove` refuses it outright, so offering it as a removable leftover is an action that cannot succeed. Its branch still reports under `branches`.
- `skills/cleanup/SKILL.md` gains the acting half — land on base, pull, delete — under the unchanged ask-before-touching rule, plus an explicit **Step 4a: End on the base branch**: cleanup finishes on the base branch, current with its remote, so the next session starts from a clean checkout instead of inheriting leftovers.

## Before / after, on the repo from the ticket

```
before:  nothing to sweep

after:   note: local main is 3 commit(s) behind origin/main (not fetched); swept against both
         Merged or upstream-gone branches:
           feature/cloudflare-migration  (current branch — check out main first, then delete)
```

## Tests

`tests/test-csw-sweep.sh` 27 → 43 assertions, `tests/test-skills.sh` +4.

- branch merged into `origin/<base>` but not local `<base>` → reported, on both the branches and worktrees paths
- merged into neither → not reported; the base is never reported despite being an ancestor of its upstream
- no upstream on the base → upstream-merged branch stays invisible, no note, `nothing to sweep` unchanged
- base level with its upstream → still swept locally, note does not fire spuriously
- the sweep moves no ref
- a merged current branch is swept, and the report says to land on base first
- the base branch is never swept, even while standing on it
- the main working tree is never listed as a removable stale worktree, but its branch still reports

The upstream fixtures are built from a real clone of a real origin, and deliberately give the shipped branch no upstream of its own, so the pre-existing `[gone]` path cannot be what reports it — only the new union can. Confirmed red before the fix, green after.

The regex-metachar regression test moved with the code it protects: it covered the current-branch filter, which no longer exists, so it now exercises the surviving base-branch filter via a base named `release/1.x`.

Full suite passes; `shellcheck --severity=warning` gate clean.

Closes #76