### PR TITLE
fix: verify ExitWorktree's discard warning instead of trusting it (#81)

### DIFF
--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -48,7 +48,32 @@ csw-config get baseBranch
 
 Capture all three now. Step 2 changes directory and Step 3 needs these values.
 
-## Step 2: Leave the worktree
+## Step 2: Pull the base branch, then leave the worktree
+
+The pull comes first, from **inside** the worktree, while the worktree still exists. Step 1
+has already confirmed the PR is `MERGED`, so `origin/<baseBranch>` is guaranteed to carry the
+merge by the time this runs — but the *local* base branch does not, and anything that compares
+this branch against a stale local base will conclude that work already on the remote is
+unmerged.
+
+From inside a worktree, `git checkout <base>` and `git fetch origin <base>:<base>` are both
+refused: the main checkout holds that branch. What works is updating that other checkout in
+place:
+
+```bash
+main_checkout=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
+git -C "$main_checkout" status --porcelain     # must be empty
+git -C "$main_checkout" pull
+```
+
+Guard it on that `status --porcelain`. If the main checkout is dirty, the pull can fail or
+conflict — skip it and say plainly that you did, rather than pulling over someone's
+uncommitted work. Likewise if the main checkout is not sitting on `<baseBranch>`: the pull
+updates whatever branch it is on, which is harmless but is not the base pull, so report that
+too. In every one of those cases a failed or skipped pull **must not block the cleanup**. What
+protects the work is the verification below, not this pull.
+
+### Leave the worktree
 
 Use the native **ExitWorktree** tool if one exists — it owns removal for worktrees it
 created. Otherwise move to the main worktree root by hand:
@@ -59,7 +84,55 @@ cd "$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)"
 
 Worktree removal must run from outside the worktree being removed.
 
-Then, **on either path**, land on the base branch and take the remote's latest:
+### When ExitWorktree warns it will discard commits
+
+`ExitWorktree` refuses to remove a worktree whose branch it believes carries unmerged
+commits, and asks to be re-invoked with `discard_changes: true`:
+
+```
+Worktree has 2 commits on worktree-fix+76-csw-sweep-misses-branches-merged-upstrea.
+Removing will discard this work permanently. Confirm with the user, then re-invoke
+with discard_changes: true — or use action: "keep" to preserve the worktree.
+```
+
+**Expect this. It is the ordinary case, not an anomaly** — cleanup always runs immediately
+after a forge-side merge, which is exactly when a branch's commits are on the remote and not
+yet anywhere the tool is looking. Neither reflex is acceptable: stalling on a warning you have
+not checked, or passing `discard_changes: true` because the PR is merged and the warning
+"must" be spurious. The second one eventually discards work that really was unmerged.
+
+Prove it instead. The refused exit leaves you still inside the worktree, so this runs from
+right there — capture the branch head **before** exiting, because afterwards the branch may
+be gone:
+
+```bash
+head_sha=$(git rev-parse HEAD)
+git fetch -q origin
+git merge-base --is-ancestor "$head_sha" "origin/<baseBranch>"
+```
+
+Exit 0 proves every commit on this branch is already in `origin/<baseBranch>`. Nothing is
+lost; re-invoke `ExitWorktree` with `discard_changes: true` and carry on.
+**Non-zero means the warning is real** — there are commits here that did not ship. Stop,
+report the SHAs (`git log --oneline "origin/<baseBranch>..HEAD"`), and do not discard.
+
+This proves safety directly rather than inferring it from the tool's warning, so it holds no
+matter what the tool is comparing against.
+
+Two things this is **not**:
+
+- **Not the branch rename.** The name in the warning is the pre-rename `worktree-<slug>` that
+  `csw:work` Step 4 renamed away, which makes the rename look causal. It is not: the commit
+  *count* is correct, and a branch name that no longer exists could not produce a correct
+  count. The stale name is display only. Renaming back will not suppress the warning, and the
+  rename is what ties the branch to its ticket — do not abandon it.
+- **Not a reason to skip Step 1.** A merged PR is not by itself proof that *this* branch head
+  is in the base. Verify the SHA.
+
+### Land on the base branch
+
+Once the worktree is gone, **on either path**, land on the base branch and take the remote's
+latest:
 
 ```bash
 git checkout "<baseBranch>"
@@ -199,6 +272,8 @@ is clean, even when it is obvious. Propose it, name what you would set it to, an
 | "The ticket is clearly done, I'll close it" | Always ask. Every time. |
 | "The sweep is empty, nothing to report" | Report the empty sweep. Silence reads as "not checked". |
 | "`csw-sweep` printed nothing, so there's nothing stale" | Check the exit code. Non-zero means the sweep did not run — unknown is not the same as absent. |
+| "The PR is merged, so ExitWorktree's discard warning is obviously spurious" | Prove it. `git merge-base --is-ancestor "$head_sha" origin/<base>` exiting 0, or stop. Reflexive `discard_changes: true` is how real work gets deleted. |
+| "The warning names a branch that no longer exists, so it's stale nonsense" | The name is display only; the commit count is correct. Run the `merge-base` check — do not dismiss it, and do not stall on it either. |
 | "The sweep flagged the branch I'm on, so it must be confused" | It is not. Land on the base branch, then delete it. Standing on shipped work is the ordinary case, not an anomaly. |
 | "`git branch -d` refused the current branch, so I'll leave it" | Refusing the *checked-out* branch is not the unmerged-commits refusal. Check out the base first, then delete. |
 | "Cleanup is done, wherever the checkout happens to be" | It ends on the base branch, current with its remote. Anything else backdates the next branch cut from it. |

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -148,6 +148,41 @@ assert_contains "$(cat "$cleanup")" "End on the base branch" \
   "cleanup: states its end state explicitly"
 assert_contains "$(cat "$cleanup")" "git branch --show-current      # must be" \
   "cleanup: verifies where it landed rather than assuming"
+# ExitWorktree's "will discard N commits" warning fires on essentially every cleanup,
+# because cleanup always runs right after a forge-side merge. It must be proven false
+# against the remote, never waved through and never stalled on.
+assert_contains "$(cat "$cleanup")" "git merge-base --is-ancestor" \
+  "cleanup: proves the discard warning false against the remote instead of trusting it"
+assert_contains "$(cat "$cleanup")" "Non-zero means the warning is real" \
+  "cleanup: a non-zero merge-base check stops the cleanup"
+assert_contains "$(cat "$cleanup")" "discard_changes: true" \
+  "cleanup: names the flag that must never be passed unverified"
+assert_contains "$(cat "$cleanup")" "display only" \
+  "cleanup: says the stale branch name in the warning is cosmetic, not a reason to dismiss the count"
+# Red flags are where an agent looks when it is about to rationalise. The verification
+# rule has to appear there too, not only in the step prose.
+red_flags=$(sed -n '/^## Red flags/,$p' "$cleanup")
+assert_contains "$red_flags" "merge-base" \
+  "cleanup: red flags forbid waving the discard warning through"
+
+# The base pull has to happen *before* ExitWorktree runs, so the tool compares against a
+# base branch that already carries the merge. Ordering is the whole point of the change,
+# and a needle-anywhere assertion cannot see ordering.
+pull_line=$(grep -n 'main_checkout" pull' "$cleanup" | head -1 | cut -d: -f1)
+leave_line=$(grep -n '^### Leave the worktree' "$cleanup" | head -1 | cut -d: -f1)
+if [ -n "$pull_line" ] && [ -n "$leave_line" ] && [ "$pull_line" -lt "$leave_line" ]; then
+  PASSES=$((PASSES + 1))
+else
+  FAILURES=$((FAILURES + 1))
+  printf 'FAIL cleanup: the base pull must precede leaving the worktree (pull at line [%s], exit at line [%s])\n' \
+    "${pull_line:-none}" "${leave_line:-none}" >&2
+fi
+# A dirty main checkout makes the pull fail or conflict; it must be skipped, not forced,
+# and its failure must never block a cleanup that Step 1 already verified is safe.
+assert_contains "$(cat "$cleanup")" 'git -C "$main_checkout" status --porcelain' \
+  "cleanup: guards the pre-exit pull against a dirty main checkout"
+assert_contains "$(cat "$cleanup")" "must not block the cleanup" \
+  "cleanup: a failed pre-exit pull is reported, not fatal"
 
 # --- batch: never auto-invoked, always explains its skips ---
 batch="$SKILLS/batch/SKILL.md"


### PR DESCRIPTION
`ExitWorktree` refuses to remove a worktree it believes carries unmerged commits and asks for
`discard_changes: true`. Because cleanup always runs immediately after a forge-side merge, that
warning fires on essentially every `/csw:cleanup` — and `skills/cleanup/SKILL.md` said nothing
about it. An agent hitting it either stalls on a warning it cannot evaluate, or waves it through
reflexively; the second habit eventually discards work that really was unmerged.

## What changed

**Verify, don't trust** (the part that matters). Before passing `discard_changes: true`, cleanup
now captures the branch head and runs `git merge-base --is-ancestor "$head_sha" origin/<base>`.
Exit 0 proves nothing is lost. Non-zero means the warning is real: stop, report the SHAs, do not
discard. This proves safety directly instead of inferring it from a tool warning, so it holds
regardless of what the tool is comparing against.

**Pull the base before exiting, not after** (ergonomics, and the experiment). Step 2 used to exit
the worktree and *then* land on the base and pull, guaranteeing the local base was stale at the
moment `ExitWorktree` ran. The pull now happens first, updating the main checkout in place —
`git checkout <base>` and `git fetch origin <base>:<base>` are both refused from inside a
worktree. Guarded on `git status --porcelain` of the main checkout, and explicitly non-fatal.

**The stale branch name is display only.** The warning shows the pre-rename `worktree-<slug>`,
which makes csw:work Step 4's rename look causal. It is not — the commit *count* is correct, and
a nonexistent branch name could not produce a correct count. The skill now says so, and says not
to "fix" this by abandoning the rename.

**Two red-flag rows**, so neither reflex survives contact with the table.

## This PR is the experiment

Per #81 there is no separate probe. Two hypotheses fit the evidence — comparison against the
stale *local* base, or against the worktree's *creation point* — and the next real cleanup
distinguishes them:

- Warning gone → hypothesis 1. Keep the reorder, note it on the issue.
- Warning persists → hypothesis 2. Revert the reorder, keep the verification, record the null
  result on the issue so the question is closed permanently.

Either way the outcome gets reported on #81.

## Tests

Eight new assertions in `tests/test-skills.sh`, all watched failing first: the `merge-base`
verification, the stop-on-non-zero rule, the `discard_changes: true` flag being named, the
display-only note, a red-flags-section check, the dirty-checkout guard, the non-fatal rule, and
a line-number ordering assertion that the pull precedes leaving the worktree — ordering is the
whole point and a needle-anywhere assertion cannot see it.

`bash tests/run-tests.sh`: all files pass (test-skills 83/83). `csw-gates --files` fires nothing;
no `bin/**` changes.

Refs #81
