### PR TITLE
fix: drop the inert pre-exit base pull, keep the verification (#81)

### DIFF
--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -48,32 +48,7 @@ csw-config get baseBranch
 
 Capture all three now. Step 2 changes directory and Step 3 needs these values.
 
-## Step 2: Pull the base branch, then leave the worktree
-
-The pull comes first, from **inside** the worktree, while the worktree still exists. Step 1
-has already confirmed the PR is `MERGED`, so `origin/<baseBranch>` is guaranteed to carry the
-merge by the time this runs — but the *local* base branch does not, and anything that compares
-this branch against a stale local base will conclude that work already on the remote is
-unmerged.
-
-From inside a worktree, `git checkout <base>` and `git fetch origin <base>:<base>` are both
-refused: the main checkout holds that branch. What works is updating that other checkout in
-place:
-
-```bash
-main_checkout=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
-git -C "$main_checkout" status --porcelain     # must be empty
-git -C "$main_checkout" pull
-```
-
-Guard it on that `status --porcelain`. If the main checkout is dirty, the pull can fail or
-conflict — skip it and say plainly that you did, rather than pulling over someone's
-uncommitted work. Likewise if the main checkout is not sitting on `<baseBranch>`: the pull
-updates whatever branch it is on, which is harmless but is not the base pull, so report that
-too. In every one of those cases a failed or skipped pull **must not block the cleanup**. What
-protects the work is the verification below, not this pull.
-
-### Leave the worktree
+## Step 2: Leave the worktree
 
 Use the native **ExitWorktree** tool if one exists — it owns removal for worktrees it
 created. Otherwise move to the main worktree root by hand:
@@ -95,11 +70,17 @@ Removing will discard this work permanently. Confirm with the user, then re-invo
 with discard_changes: true — or use action: "keep" to preserve the worktree.
 ```
 
-**Expect this. It is the ordinary case, not an anomaly** — cleanup always runs immediately
-after a forge-side merge, which is exactly when a branch's commits are on the remote and not
-yet anywhere the tool is looking. Neither reflex is acceptable: stalling on a warning you have
-not checked, or passing `discard_changes: true` because the PR is merged and the warning
-"must" be spurious. The second one eventually discards work that really was unmerged.
+**Expect this on every single cleanup.** The tool compares the branch against the worktree's
+**creation point** — the commit the base branch was on when the worktree was cut — and cleanup
+by definition runs after commits have been added since. So the warning **cannot be suppressed
+by anything cleanup does**. Pulling or fast-forwarding the base first does not help: that was
+measured directly, by moving the local base *ahead* of the branch head before exiting and
+watching the warning fire anyway. Do not re-run that experiment.
+
+Because it always fires, it carries no information on its own, and both reflexes it invites
+are wrong: stalling on a warning you have not checked, and passing `discard_changes: true`
+because the PR is merged so the warning "must" be spurious. The second one eventually discards
+work that really was unmerged.
 
 Prove it instead. The refused exit leaves you still inside the worktree, so this runs from
 right there — capture the branch head **before** exiting, because afterwards the branch may

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -164,25 +164,13 @@ assert_contains "$(cat "$cleanup")" "display only" \
 red_flags=$(sed -n '/^## Red flags/,$p' "$cleanup")
 assert_contains "$red_flags" "merge-base" \
   "cleanup: red flags forbid waving the discard warning through"
-
-# The base pull has to happen *before* ExitWorktree runs, so the tool compares against a
-# base branch that already carries the merge. Ordering is the whole point of the change,
-# and a needle-anywhere assertion cannot see ordering.
-pull_line=$(grep -n 'main_checkout" pull' "$cleanup" | head -1 | cut -d: -f1)
-leave_line=$(grep -n '^### Leave the worktree' "$cleanup" | head -1 | cut -d: -f1)
-if [ -n "$pull_line" ] && [ -n "$leave_line" ] && [ "$pull_line" -lt "$leave_line" ]; then
-  PASSES=$((PASSES + 1))
-else
-  FAILURES=$((FAILURES + 1))
-  printf 'FAIL cleanup: the base pull must precede leaving the worktree (pull at line [%s], exit at line [%s])\n' \
-    "${pull_line:-none}" "${leave_line:-none}" >&2
-fi
-# A dirty main checkout makes the pull fail or conflict; it must be skipped, not forced,
-# and its failure must never block a cleanup that Step 1 already verified is safe.
-assert_contains "$(cat "$cleanup")" 'git -C "$main_checkout" status --porcelain' \
-  "cleanup: guards the pre-exit pull against a dirty main checkout"
-assert_contains "$(cat "$cleanup")" "must not block the cleanup" \
-  "cleanup: a failed pre-exit pull is reported, not fatal"
+# Measured in the cleanup for #82: local base was moved *ahead* of the branch head before the
+# exit and the warning still fired, so the comparison is against the worktree's creation point.
+# Saying so is what stops the next reader re-running the same disproved experiment.
+assert_contains "$(cat "$cleanup")" "creation point" \
+  "cleanup: names what the discard warning actually compares against"
+assert_contains "$(cat "$cleanup")" "cannot be suppressed" \
+  "cleanup: says the warning is unavoidable, so verification is the only defence"
 
 # --- batch: never auto-invoked, always explains its skips ---
 batch="$SKILLS/batch/SKILL.md"


### PR DESCRIPTION
Follow-up to #82, which shipped a deliberate experiment. The experiment came back negative, and
this lands the outcome #81 prescribed for that case.

## The measurement

#82 moved the base pull ahead of the worktree exit to test whether `ExitWorktree`'s discard
warning came from comparing against a stale *local* base. Run during that PR's own cleanup:

| moment | local `main` | `origin/main` | creation point | branch HEAD |
|---|---|---|---|---|
| before the pull | `8e008f2` | `8e008f2` (cached) | `8e008f2` | `aea691f` |
| after the pull  | `7e8c84d` | `7e8c84d`          | `8e008f2` | `aea691f` |

`7e8c84d` is #82's merge commit and has `aea691f` as a parent, so after the pull the branch head
**was** on local `main`. The warning fired anyway:

```
Worktree has 1 commit on worktree-fix+81-csw-cleanup-should-verify-exitworktree-s.
```

The comparison is therefore against the worktree's **creation point**, which nothing cleanup does
can move. Full write-up on #81.

## What this reverts

The pre-exit pull, its dirty-checkout guard, and the three assertions that pinned the ordering.
It is inert with respect to the warning, and the post-exit `git checkout <base> && git pull`
already leaves the checkout current — the only thing the reorder was really buying. Leaving it in
would encode a causal story this run disproved, and invite the next reader to re-run the same
experiment.

## What this keeps, and sharpens

The `merge-base --is-ancestor` verification — the part that actually protects work — plus its red
flags. Its framing changes from hypothesis to settled fact: the warning fires on **every** cleanup
and cannot be suppressed, therefore it carries no information on its own, and the check against
`origin/<base>` is the only thing standing between a reflexive `discard_changes: true` and real
work being deleted. The skill now says so explicitly, and says not to re-run the disproved
experiment.

The verification is not theoretical — it ran for real during #82's cleanup: exit 0 before
discarding, then `git branch -d` (lowercase, which refuses unmerged branches) deleted the branch
without complaint. Nothing was lost.

## Tests

Two new assertions, watched failing first: that cleanup names the **creation point** as what the
warning compares against, and that it says the warning **cannot be suppressed**. Then the three
ordering assertions were watched failing after the revert — confirming they tested the reorder and
nothing else — before removal.

`bash tests/run-tests.sh`: all files pass (test-skills 82/82). `csw-gates --files` fires nothing.

Net: 19 insertions, 50 deletions.

Closes #81
