### PR TITLE
fix: scope csw:cleanup's sibling-PR search to the repo owner (#83)

### DIFF
--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -231,14 +231,38 @@ behind its remote, is exactly the state that silently backdates the next branch 
 Report the ticket's current state. If the PR body said `Closes <TICKET>`, the tracker may
 have moved it already — check rather than assume.
 
-Then look for siblings before declaring it done:
+Then look for siblings before declaring it done. **Scope the search to this repo's owner.**
+`gh search prs` with no scope searches all of GitHub, which is almost never what this step
+wants:
 
 ```bash
-gh search prs "<TICKET>" --state open --json repository,number,title,url
+owner=$(gh repo view --json owner --jq .owner.login)
+gh search prs "<TICKET>" --owner "$owner" --state open --json repository,number,title,url
 ```
 
-A platform ticket is not done while its docs counterpart is still open. Report any sibling
-PRs you find.
+With `tracker: linear` the ticket is a distinctive string like `ENG-123`, and even that query
+wants the scope. With `tracker: github` it is a **bare number**, which matches every PR whose
+title happens to contain those digits — version bumps, unrelated issue numbers, strangers'
+repos. Run unscoped for `81` and you get thirty PRs from thirty projects, none of them
+siblings.
+
+Scoping is the floor, not the whole answer. For a numeric ticket, also search what the work
+was actually *about*, and search the `#<TICKET>` form against titles and bodies rather than the
+bare digits:
+
+```bash
+gh search prs "<a distinctive phrase from the ticket title>" --owner "$owner" --state open --json repository,number,title,url
+gh search prs "#<TICKET>" --owner "$owner" --match title,body --state open --json repository,number,title,url
+```
+
+**A long result list is a symptom, not a finding.** A couple of candidates is an answer worth
+reading; thirty means the query was too broad. Narrow it and run it again — do not paste the
+list into the report. This step exists so that one genuine cross-repo sibling gets noticed, and
+burying it in thirty false positives is indistinguishable from missing it.
+
+A platform ticket is not done while its docs counterpart is still open. Report the siblings you
+find — and when the scoped search comes back empty, report that too. `[]` is the answer this
+step is usually looking for, and saying so is what shows it ran.
 
 **Always ask before closing a ticket.** Even when everything is merged, even when the sweep
 is clean, even when it is obvious. Propose it, name what you would set it to, and wait.
@@ -262,3 +286,5 @@ is clean, even when it is obvious. Propose it, name what you would set it to, an
 | "`git branch -d` refused, I'll use -D" | Refusal means unmerged commits. Investigate. |
 | "Uncommitted changes in the worktree are just scratch" | Show them first. That call is not yours. |
 | "One repo's PR is merged, so the ticket is done" | Check for siblings in other repos. |
+| "The sibling search returned thirty open PRs" | That is an unscoped query, not thirty siblings. Add `--owner` and run it again. |
+| "The ticket number is enough of a query on its own" | Not for a `github` ticket. Scope it with `--owner`, then search the title too. |

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -131,6 +131,21 @@ assert_contains "$(cat "$cleanup")" "on either path" "cleanup: pulls the base br
 assert_contains "$(cat "$cleanup")" "not only for the manual path" "cleanup: says the pull is not optional"
 assert_contains "$(cat "$cleanup")" "Always ask before closing" "cleanup: never closes a ticket unasked"
 assert_contains "$(cat "$cleanup")" "sibling" "cleanup: checks for sibling PRs in other repos"
+# The sibling search must be scoped to this repo's owner. Unscoped, `gh search prs` runs
+# across all of GitHub, and with `tracker: github` the ticket is a bare number — searching
+# for 81 returned 30 strangers' PRs and not one sibling.
+assert_contains "$(cat "$cleanup")" "gh repo view --json owner" \
+  "cleanup: derives the owner to scope the sibling search to"
+# Matched at the start of a line so the skill can still *name* the unscoped form in prose to
+# warn against it; what must not exist is a runnable invocation missing --owner.
+unscoped=$(grep -E '^[[:space:]]*gh search prs' "$cleanup" | grep -v -- '--owner' || true)
+assert_eq "$unscoped" "" "cleanup: no sibling search runs unscoped across all of GitHub"
+# A numeric ticket is a weak query even when scoped, and a long result set means the query
+# was too broad — not that there are many siblings.
+assert_contains "$(cat "$cleanup")" "--match title,body" \
+  "cleanup: offers a more precise query than a bare number for github tickets"
+assert_contains "$(cat "$cleanup")" "A long result list is a symptom" \
+  "cleanup: says a long result set means a bad query, not many siblings"
 assert_contains "$(cat "$cleanup")" "never require a separate instruction" "cleanup: branch cleanup is unconditional"
 assert_contains "$(cat "$cleanup")" "gh pr view --json state,mergedAt" "cleanup: verifies the PR is merged before removing anything"
 assert_contains "$(cat "$cleanup")" "unknown, not absent" "cleanup: a failed sweep is reported distinctly from an empty one"
@@ -164,6 +179,8 @@ assert_contains "$(cat "$cleanup")" "display only" \
 red_flags=$(sed -n '/^## Red flags/,$p' "$cleanup")
 assert_contains "$red_flags" "merge-base" \
   "cleanup: red flags forbid waving the discard warning through"
+assert_contains "$red_flags" "--owner" \
+  "cleanup: red flags catch the unscoped sibling search"
 # Measured in the cleanup for #82: local base was moved *ahead* of the branch head before the
 # exit and the warning still fired, so the comparison is against the worktree's creation point.
 # Saying so is what stops the next reader re-running the same disproved experiment.


### PR DESCRIPTION
`csw:cleanup` Step 5 ran `gh search prs "<TICKET>" --state open` with no scope. Across all of
GitHub, a bare-number `github` ticket matches anything containing those digits — the search for
#81 came back with 30 PRs from strangers' repos and not one sibling. That is worse than a
missing check: 30 false positives is what an agent skims past, and "report any sibling PRs you
find" then presents noise as a finding.

## What changed

- The search is scoped with `--owner "$owner"`, derived from `gh repo view --json owner`.
- Two more precise follow-up queries for numeric tickets: the ticket *title*, and the `#<TICKET>`
  form with `--match title,body`.
- The step now says a long result list is a symptom of a broad query, not evidence of many
  siblings — narrow and re-run rather than pasting the list into the report.
- Empty results get reported too. `[]` is the normal answer, and saying so is what shows the
  step ran.
- Two red flags covering both failure modes.

## Tests

`tests/test-skills.sh` gains five assertions: the owner is derived, no runnable `gh search prs`
line lacks `--owner`, the precise-query and long-list guidance are present, and the red-flag
table covers it. The `--owner` check is anchored to line starts so the skill can still name the
unscoped form in prose to warn against it; verified it flags the pre-change file and passes on
the new one.

`bash tests/run-tests.sh` — all test files pass. No gates fired (`bin/**` untouched).

Closes #83