### PR TITLE
fix: prune before sweeping so csw-sweep's [gone] detection actually fires (#87)

### DIFF
--- a/bin/csw-sweep
+++ b/bin/csw-sweep
@@ -81,7 +81,8 @@ stale_branches() {
   if [ -n "$upstream" ]; then
     merged=$(printf '%s\n%s\n' "$merged" "$(merged_into "$upstream")")
   fi
-  # Upstream deleted — what `gh pr merge --delete-branch` leaves behind.
+  # Upstream deleted — what `gh pr merge --delete-branch` leaves behind. See
+  # prune_note(): this arm is only as current as the last prune.
   gone=$(git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads 2>/dev/null \
     | awk '$2 == "[gone]" { print $1 }')
   # The base itself is excluded -- it is the thing everything else is measured
@@ -118,6 +119,47 @@ base_behind_note() {
   [ -n "$count" ] && [ "$count" != "0" ] || return 0
   printf 'note: local %s is %s commit(s) behind %s (not fetched); swept against both\n' \
     "$BASE" "$count" "$upstream"
+}
+
+# The same treatment for the other silent staleness, the one that hides whole
+# branches rather than a few commits.
+#
+# stale_branches()'s `[gone]` arm reads `%(upstream:track)`, which reports
+# `[gone]` only once the upstream ref is missing *locally* -- a statement about
+# `refs/remotes`, not about the server. Deleting a branch on the forge, which is
+# exactly what `gh pr merge --delete-branch` does, leaves
+# `refs/remotes/origin/<name>` on disk until something prunes, and a plain
+# `git fetch`/`git pull` does not. csw-sweep cannot close that gap itself:
+# never fetching is a deliberate invariant (see base_upstream), and pruning
+# mutates refs. It cannot even detect the gap -- a live upstream and an unpruned
+# dead one are indistinguishable from here. So say what it depends on.
+#
+# Only when it could change the answer, though. The branches at risk are those
+# that still have a resolving upstream, are not the base, and are not already in
+# the report: those are precisely the names a prune could add. With none of them
+# the caveat has nothing to attach to, and a note on every clean sweep is noise
+# that teaches the reader to skip the note line -- which would cost the
+# base_behind_note above its audience too.
+prune_note() { # branch names already in the report, one per line
+  local reported=$1 at_risk count
+  # `%(upstream)` is read from config and stays set after a prune, so it is the
+  # test for "has an upstream at all"; `%(upstream:track)` then separates a
+  # known-gone upstream from one that still resolves. Neither a branch name nor
+  # an upstream ref name can contain a TAB, so it is a safe field separator.
+  at_risk=$(git for-each-ref --format='%(refname:short)%09%(upstream)%09%(upstream:track)' refs/heads 2>/dev/null \
+    | awk -F'\t' '$2 != "" && $3 != "[gone]" { print $1 }' \
+    | grep -Fvx "$BASE" || true)
+  # Subtract what is already reported. Done in awk against an exact-match set
+  # rather than `grep -vf`, whose patterns would be substrings and would drop
+  # `feat/a` from the at-risk set merely because `feat/ab` was reported.
+  count=$(printf '%s\n' "$at_risk" | awk -v rep="$reported" '
+    BEGIN { n = split(rep, a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") seen[a[i]] = 1 }
+    $0 != "" && !($0 in seen) { c++ }
+    END { print c + 0 }
+  ')
+  [ "$count" != "0" ] || return 0
+  printf 'note: upstream-gone detection is only as fresh as the last prune; %s branch(es) still resolve their upstream and may already be deleted on the remote (git fetch --prune)\n' \
+    "$count"
 }
 
 # The main working tree's root, or empty if it cannot be determined. Used to
@@ -193,9 +235,10 @@ case "${1:-}" in
   ''|report)
     b=$(stale_branches)
     w=$(stale_worktrees)
-    # Before the findings, and before "nothing to sweep" — the caveat has to
+    # Before the findings, and before "nothing to sweep" — the caveats have to
     # reach the reader whether or not anything was found.
     base_behind_note
+    prune_note "$b"
     if [ -z "$b" ] && [ -z "$w" ]; then
       printf 'nothing to sweep\n'
       exit 0

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -117,13 +117,23 @@ latest:
 
 ```bash
 git checkout "<baseBranch>"
-git pull
+git pull --prune
 ```
 
 `git pull` is not optional and is not only for the manual path. The merge you just landed
 is on the remote, not in this checkout — skip the pull and the local base branch sits one
 commit behind from the moment cleanup finishes, which then silently backdates the next
 worktree branched from it. If the pull fails, say so and stop before removing anything.
+
+`--prune` is not cosmetic either — it is what makes Step 4's sweep able to see anything at
+all. `csw-sweep` finds upstream-deleted branches through `%(upstream:track)` reporting
+`[gone]`, and that says `[gone]` only once `refs/remotes/origin/<name>` is missing **locally**.
+Merging with `--delete-branch` deletes the branch on the forge; **only a prune** removes the
+remote-tracking ref that mirrors it, and a plain `git pull` does not prune. Drop the flag and
+that half of the sweep silently never fires — every leftover it reports comes from the
+merged-into-base half instead, which is exactly the half that cannot see a branch that shipped
+without becoming an ancestor of the base. The sweep cannot do this for itself: it must never
+fetch, and pruning mutates refs.
 
 ## Step 3: Remove this worktree and branch
 
@@ -182,6 +192,13 @@ This is the part that turns *"any remaining worktrees or merged branches?"* from
 someone has to remember into something reported unprompted. Report what it found even when
 it found nothing.
 
+The sweep may lead with a `note:` line — the local base being behind its upstream, or
+upstream-gone detection being only as fresh as the last prune. Those are caveats on how far
+the answer reaches, so pass them on with the findings rather than trimming them off. On the
+chained path Step 2's `git pull --prune` has already refreshed the prune half; a prune note
+surviving that means some branch still resolves an upstream this run has not pruned since, and
+it is honest reporting, not a failure.
+
 Then **ask before touching any of it**. These are other people's leftovers as far as this
 session is concerned — list them, propose removing them, and wait. A vague "sure, clean it
 up" is not approval for a list: either they name what goes, or ask again.
@@ -203,7 +220,7 @@ of the sweep — land first, then delete:
 
 ```bash
 git checkout "<baseBranch>"
-git pull
+git pull --prune
 git branch -d "<the current branch the sweep flagged>"
 ```
 
@@ -277,6 +294,8 @@ is clean, even when it is obvious. Propose it, name what you would set it to, an
 | "The ticket is clearly done, I'll close it" | Always ask. Every time. |
 | "The sweep is empty, nothing to report" | Report the empty sweep. Silence reads as "not checked". |
 | "`csw-sweep` printed nothing, so there's nothing stale" | Check the exit code. Non-zero means the sweep did not run — unknown is not the same as absent. |
+| "`--prune` on the pull is tidiness, I'll use plain `git pull`" | It is load-bearing. Without it `[gone]` never fires and half the sweep silently stops working. |
+| "The sweep's `note:` line is chatter, I'll report the findings" | The note says how far the answer reaches. Report it with the findings. |
 | "The PR is merged, so ExitWorktree's discard warning is obviously spurious" | Prove it. `git merge-base --is-ancestor "$head_sha" origin/<base>` exiting 0, or stop. Reflexive `discard_changes: true` is how real work gets deleted. |
 | "The warning names a branch that no longer exists, so it's stale nonsense" | The name is display only; the commit count is correct. Run the `merge-base` check — do not dismiss it, and do not stall on it either. |
 | "The sweep flagged the branch I'm on, so it must be confused" | It is not. Land on the base branch, then delete it. Standing on shipped work is the ordinary case, not an anomaly. |

--- a/tests/test-csw-sweep.sh
+++ b/tests/test-csw-sweep.sh
@@ -83,6 +83,15 @@ clean=$(make_repo)
 assert_eq "$(cd "$clean" && "$BIN/csw-sweep" branches)" "" "clean repo has no branches to sweep"
 assert_contains "$(cd "$clean" && "$BIN/csw-sweep")" "nothing to sweep" "clean repo reports nothing to sweep"
 assert_status 0 "clean sweep exits 0" -- in_dir "$clean" "$BIN/csw-sweep"
+# ...and says nothing about prunes. No branch here tracks anything, so the
+# `[gone]` arm has nothing it could be stale about; a caveat that fires on every
+# clean sweep is noise that trains the reader to skip the note line.
+case "$(cd "$clean" && "$BIN/csw-sweep")" in
+  *prune*)
+    assert_eq "prune-note-without-tracking-branches" "no-note" \
+      "a repo with no tracking branches produces no prune caveat" ;;
+  *) PASSES=$((PASSES + 1)) ;;
+esac
 
 # A `.` in the BASE branch name must not act as a regex wildcard and swallow an
 # unrelated merged branch: `release/1.x` as a BRE pattern also matches
@@ -388,6 +397,99 @@ else
         "a base level with its upstream produces no staleness note" ;;
     *) PASSES=$((PASSES + 1)) ;;
   esac
+fi
+
+# --- `[gone]` detection depends on a prune, and the report says so ------------
+#
+# `%(upstream:track)` reports `[gone]` only once the remote-tracking ref is
+# missing *locally*, which is a statement about `refs/remotes`, not about the
+# server. Deleting a branch on the forge -- what `gh pr merge --delete-branch`
+# does -- leaves `refs/remotes/origin/<name>` sitting on disk until something
+# prunes, and a plain `git fetch`/`git pull` does not prune. These tests pin
+# that dependency rather than leaving it implicit, so the day someone drops the
+# `--prune` from csw:cleanup the sweep does not go quietly half-blind.
+#
+# make_gone_clone prints the path of a clone whose `feat/deleted-upstream`
+# tracks an origin branch that has since been deleted on the origin. That branch
+# is an ancestor of neither the local base nor its upstream -- it shipped the way
+# a squash-merge ships -- so `merged_into` cannot rescue it and `[gone]` is its
+# only route into the sweep.
+make_gone_clone() {
+  local origin parent clone
+  origin=$(make_repo)
+  (
+    cd "$origin" || exit 1
+    git checkout -q -b feat/deleted-upstream
+    printf 'g\n' >g.txt
+    git add -A && git commit -qm "work that shipped by squash-merge"
+    git checkout -q main
+  ) || return 1
+  parent=$(mktemp -d)
+  TMPDIRS+=("$parent")
+  clone="$parent/work"
+  git clone -q "$origin" "$clone" || return 1
+  write_config "$clone" <<'JSON'
+{ "baseBranch": "main", "worktreeDir": ".claude/worktrees" }
+JSON
+  (
+    cd "$clone" || exit 1
+    git config user.email test@example.com
+    git config user.name "CSW Test"
+    git config commit.gpgsign false
+    git branch -q --track feat/deleted-upstream origin/feat/deleted-upstream
+  ) || return 1
+  # The forge-side delete. Deliberately NOT `git push origin --delete` from the
+  # clone: that removes the clone's own remote-tracking ref as a side effect and
+  # would hand the test the pruned state it exists to prove is absent.
+  git -C "$origin" branch -q -D feat/deleted-upstream || return 1
+  printf '%s\n' "$clone"
+}
+
+gonerepo=$(make_gone_clone) || gonerepo=""
+if [ -z "$gonerepo" ]; then
+  FAILURES=$((FAILURES + 1))
+  printf 'FAIL could not build the deleted-upstream fixture\n' >&2
+else
+  # A plain fetch -- exactly what `git pull` does -- leaves the stale
+  # remote-tracking ref in place, so the branch is invisible to the sweep.
+  git -C "$gonerepo" fetch -q origin
+  unpruned=$(cd "$gonerepo" && "$BIN/csw-sweep" branches)
+  case "$unpruned" in
+    *feat/deleted-upstream*)
+      assert_eq "swept-without-prune" "not-swept" \
+        "without a prune the [gone] arm cannot see a branch deleted on the remote" ;;
+    *) PASSES=$((PASSES + 1)) ;;
+  esac
+
+  # ...which makes `nothing to sweep` an answer the reader cannot trust. Say so.
+  unpruned_report=$(cd "$gonerepo" && "$BIN/csw-sweep")
+  assert_contains "$unpruned_report" "nothing to sweep" \
+    "the unpruned sweep finds nothing, which is the whole hazard"
+  assert_contains "$unpruned_report" "only as fresh as the last prune" \
+    "the report warns that upstream-gone detection depends on a prune"
+  assert_contains "$unpruned_report" "git fetch --prune" \
+    "the prune caveat names the command that refreshes it"
+
+  # After the prune the same branch reports, via the `[gone]` arm alone.
+  git -C "$gonerepo" fetch -q --prune origin
+  assert_contains "$(cd "$gonerepo" && "$BIN/csw-sweep" branches)" "feat/deleted-upstream" \
+    "after a prune the [gone] arm sweeps the branch deleted on the remote"
+
+  # ...and the caveat retires with it: no branch is left whose absence from the
+  # report a prune could still explain.
+  pruned_report=$(cd "$gonerepo" && "$BIN/csw-sweep")
+  case "$pruned_report" in
+    *"last prune"*)
+      assert_eq "prune-note-after-prune" "no-note" \
+        "once every tracking branch is [gone] or reported, the prune caveat retires" ;;
+    *) PASSES=$((PASSES + 1)) ;;
+  esac
+
+  # Still read-only: emitting the caveat must not tempt the sweep into fetching.
+  gone_before=$(cd "$gonerepo" && git for-each-ref --format='%(refname) %(objectname)' | sort)
+  (cd "$gonerepo" && "$BIN/csw-sweep" >/dev/null)
+  gone_after=$(cd "$gonerepo" && git for-each-ref --format='%(refname) %(objectname)' | sort)
+  assert_eq "$gone_after" "$gone_before" "the sweep still moves no ref while reporting the prune caveat"
 fi
 
 report

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -130,6 +130,15 @@ assert_contains "$(cat "$cleanup")" "git worktree prune" "cleanup: prunes stale 
 assert_contains "$(cat "$cleanup")" "on either path" "cleanup: pulls the base branch on both paths"
 assert_contains "$(cat "$cleanup")" "not only for the manual path" "cleanup: says the pull is not optional"
 assert_contains "$(cat "$cleanup")" "Always ask before closing" "cleanup: never closes a ticket unasked"
+# csw-sweep's `[gone]` arm reads `%(upstream:track)`, which only says `[gone]` once the
+# remote-tracking ref is missing locally — and a plain `git pull` does not prune, so a branch
+# deleted on the forge stays invisible to it. The sweep cannot fix this itself (it must never
+# fetch), so the prune has to happen here, before Step 4 runs.
+bare_pull=$(grep -nE '^[[:space:]]*git pull([[:space:]]|$)' "$cleanup" | grep -v -- '--prune' || true)
+assert_eq "$bare_pull" "" \
+  "cleanup: every runnable git pull prunes, so the sweep's [gone] arm reads fresh state"
+assert_contains "$(cat "$cleanup")" "only a prune" \
+  "cleanup: says why the prune is load-bearing, not cosmetic"
 assert_contains "$(cat "$cleanup")" "sibling" "cleanup: checks for sibling PRs in other repos"
 # The sibling search must be scoped to this repo's owner. Unscoped, `gh search prs` runs
 # across all of GitHub, and with `tracker: github` the ticket is a bare number — searching


### PR DESCRIPTION
`csw-sweep`'s `[gone]` arm reads `%(upstream:track)`, which reports `[gone]` only once
`refs/remotes/origin/<name>` is missing **locally**. `gh pr merge --delete-branch` deletes the
branch on the forge; only a prune removes the local mirror, and nothing in the workflow prunes —
`csw:cleanup`'s `git pull` does not, absent `fetch.prune`. So that arm has never fired in this
repo. Every leftover the sweep has ever found came from the merged-into-base arm, which is
exactly the arm that cannot see a branch that shipped without becoming an ancestor of the base.

Both fixes the ticket proposes, which it correctly calls complementary rather than alternatives:

**1. Prune in the skill.** `csw:cleanup` Step 2 now runs `git pull --prune`, so by Step 4 the
sweep reads accurate `[gone]` state. The reason is written into the skill so the flag does not
get "tidied" away later, and there is a red-flag row for the same. The sweep cannot do this for
itself — never fetching is a deliberate invariant, and pruning mutates refs.

**2. Say so in the report.** `csw-sweep` now emits a `note:` line, the same treatment
`base_behind_note()` already gives the other silent staleness, so standalone invocations with no
skill wrapped around them get the caveat too:

```
note: upstream-gone detection is only as fresh as the last prune; 1 branch(es) still resolve
their upstream and may already be deleted on the remote (git fetch --prune)
nothing to sweep
```

It fires only when it could change the answer — when some branch that is not the base and is not
already in the report still resolves an upstream. Those are precisely the names a prune could
add. Unconditional would be noise that teaches the reader to skip `note:` lines, costing
`base_behind_note` its audience too.

## Tests

`tests/test-csw-sweep.sh` pins the prune dependency rather than leaving it implicit: a branch
deleted **on the origin** is invisible to the sweep after a plain fetch and reported after
`git fetch --prune`; the caveat appears in the first report and retires in the second; a repo
with no tracking branches gets no caveat at all; and the sweep still moves no ref while emitting
it. The fixture deletes the branch in the origin repo rather than with `git push origin --delete`
— the latter drops the clone's own remote-tracking ref as a side effect and would hand the test
the pruned state it exists to prove is absent.

`tests/test-skills.sh` asserts every runnable `git pull` in cleanup prunes, and that the skill
says why.

Full suite green (415 assertions across 10 files); the `bin/**` shellcheck gate is clean.

Closes #87