### PR TITLE
feat: report cap overflow separately, and add /csw:batch --dry-run (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ loop. Anything that does not reach merge-ready is left as a **draft** PR with a 
 the ticket, so preview automation filters it out and the morning review only sees PRs that
 are genuinely asking to be merged.
 
+```
+/csw:batch --dry-run
+```
+
+Runs the selection and stops — no dispatch, no worktrees, no branches, no PRs, no ticket
+state changes. It prints what would dispatch, what fell **below the cap**, and what was
+**excluded** and why. Those last two are reported apart on purpose: "would have run with a
+bigger cap" is an argument about the cap, and "blocked by ENG-1088" is an argument about the
+ticket. Pass a lower cap alongside it — `/csw:batch 2 --dry-run` — to see where a smaller
+night would cut.
+
 ## Install
 
 ```
@@ -93,6 +104,7 @@ A different project is a config file, not a fork. Full reference:
 | `/csw:merge` | Merge | Usually natural language: "go for merge" |
 | `/csw:cleanup` | Cleanup | Usually automatic, chained from merge |
 | `/csw:batch` | Nightly loop | Command only — never inferred |
+| `/csw:batch --dry-run` | Nightly loop | Selection only, no side effects |
 
 ## What happened to v0.x
 

--- a/bin/csw-batch-filter
+++ b/bin/csw-batch-filter
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """csw-batch-filter — choose tonight's batch from a list of candidate tickets.
 
-Reads a JSON array of tickets on stdin, writes {"selected": [...], "skipped": [...]}
-on stdout. Three filters, in this order, because each one depends on the last:
+Reads a JSON array of tickets on stdin, writes
+{"selected": [...], "belowCap": [...], "skipped": [...]} on stdout. Three filters, in
+this order, because each one depends on the last:
 
   1. Blocked or not-Todo tickets are dropped outright.
   2. Same-surface clusters keep only their highest-priority member. Two tickets on
@@ -11,6 +12,13 @@ on stdout. Three filters, in this order, because each one depends on the last:
   3. Single-writer labels (migrations, by default) admit one ticket per batch.
      Two agents each writing "the next migration number" both validate against
      main and one still has to be redone rather than rebased.
+
+Then the cap, which is not a fourth filter and is deliberately reported apart from the
+three. A filter says "must not run tonight"; the cap says "would have run with a bigger
+cap". Folding both into one `skipped` array left nothing downstream able to tell them
+apart — no honest dry run, and no way to tune the exclusion heuristics against real
+batches, which is the only way they get tuned at all. `belowCap` holds the cap's
+overflow in dispatch order; `skipped` holds genuine exclusions and nothing else.
 
 All input — stdin and config alike — is untrusted. Bad input is a clean, single-line
 "csw-batch-filter: <message>" on stderr and exit 2, matching the four shell tools in
@@ -206,19 +214,24 @@ def main():
                 claimed[label] = t["id"]
         admitted.append(t)
 
+    # admitted is already in dispatch order, so the slice boundary is the cap and the
+    # tail below it is exactly what a larger cap would have picked up next.
     selected = admitted[:max_tickets]
-    for t in admitted[max_tickets:]:
-        skipped.append({"id": t["id"], "reason": "batch cap (%d)" % max_tickets})
+    below_cap = admitted[max_tickets:]
 
     # This runs unattended overnight, so it must catch its own bugs rather than
     # ship a silently wrong batch: every input ticket must appear in exactly one
-    # of selected/skipped, never zero and never both.
-    out_ids = [t["id"] for t in selected] + [s["id"] for s in skipped]
+    # of selected/belowCap/skipped, never zero and never more than one.
+    out_ids = ([t["id"] for t in selected] + [t["id"] for t in below_cap]
+               + [s["id"] for s in skipped])
     if set(out_ids) != {t["id"] for t in tickets} or len(out_ids) != len(set(out_ids)):
         die("internal error: filter dropped or duplicated a ticket "
-            "(selected=%d skipped=%d input=%d)" % (len(selected), len(skipped), len(tickets)))
+            "(selected=%d belowCap=%d skipped=%d input=%d)"
+            % (len(selected), len(below_cap), len(skipped), len(tickets)))
 
-    json.dump({"selected": [t["id"] for t in selected], "skipped": skipped},
+    json.dump({"selected": [t["id"] for t in selected],
+               "belowCap": [t["id"] for t in below_cap],
+               "skipped": skipped},
               sys.stdout, indent=2)
     sys.stdout.write("\n")
 

--- a/skills/batch/SKILL.md
+++ b/skills/batch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: batch
 description: Dispatch a night's batch of Todo tickets — one worktree and one pull request each — and leave a morning summary. Run explicitly; never inferred.
-argument-hint: "[max-tickets]"
+argument-hint: "[max-tickets] [--dry-run]"
 disable-model-invocation: true
 ---
 
@@ -9,7 +9,17 @@ disable-model-invocation: true
 
 **Announce at start:** "Using csw:batch to dispatch tonight's tickets."
 
-Optional override for tonight's cap: $ARGUMENTS
+Tonight's invocation carried: $ARGUMENTS
+
+Two modifiers, and they compose:
+
+- **A bare integer** lowers tonight's cap. Never raises it — see Step 2.
+- **`--dry-run`**, also written `dry-run` or `dry run`, runs selection and stops — see
+  Step 3.
+
+So `/csw:batch 2 --dry-run` shows tonight's plan cut at 2 without dispatching anything.
+Anything else in $ARGUMENTS is not a modifier: say what you ignored and why, rather than
+guessing at what it meant.
 
 ## Before the first run: the prerequisite
 
@@ -61,6 +71,19 @@ review: preview environments merge every open non-draft PR together, so the morn
 tests the *combination*. Past three or four, a bug found there cannot be attributed without
 bisecting, and the review gate is what this whole design rests on.
 
+The cap is not a fourth filter, and the output keeps it separate. Three keys come back:
+
+| Key | Contents |
+|---|---|
+| `selected` | Dispatching tonight, in dispatch order. |
+| `belowCap` | Passed every filter and still fell outside the cap, in the order it would have been dispatched. |
+| `skipped` | Genuinely excluded — blocked, not Todo, same-surface cluster, single-writer conflict — each with its reason. |
+
+`belowCap` is never an exclusion, and `skipped` never blames the cap. Keep them apart
+everywhere you report them. Merged, nothing downstream can tell "must not run tonight" from
+"would have run with a bigger cap" — and those two answer different questions: the first is
+tuning data for the exclusion heuristics, the second is an argument for a different cap.
+
 **If `csw-batch-filter` exits non-zero, the batch does not run.** Report its stderr message
 verbatim, say plainly that selection failed and no tickets were dispatched, and stop — do not
 continue to Step 3. A failed selection is never an empty selection: a malformed ticket, a bad
@@ -77,25 +100,59 @@ csw-config get batch.maxTickets
 
 Apply the override after the filter returns. If $ARGUMENTS is a positive integer smaller than
 the length of `selected`, keep only its first that many entries — `selected` is already in
-dispatch order — and move the rest into the skip list with reason `batch cap override (<n>)`.
+dispatch order — and move the rest to the **front** of `belowCap`, ahead of the filter's own
+entries. They belong there and not in the skip list: nothing excluded them, and they are the
+very next tickets that would dispatch if the cap went back up. Front, because they outrank
+everything the filter had already put below the cap.
+
 If $ARGUMENTS is absent, not a positive integer, or greater than or equal to the value
 `csw-config get batch.maxTickets` just printed, ignore it, say so in the summary, and dispatch
 the filter's own `selected` unchanged. Never guess at what a malformed override meant, and
 never guess at the configured cap either — read it.
 
-## Step 3: Confirm the selection
+## Step 3: If this is a dry run, report and stop
 
-Show `selected` and every `skipped` entry with its reason, then wait for a go-ahead. This is
-the last human checkpoint before an unattended night — once given, Steps 4 through 6 run
-straight through with no further prompting and no further confirmation, until the morning
-summary reports what happened.
+A dry run answers "what would tonight do?" and nothing else. **It has no side effects:**
+no dispatch, no worktree, no branch, no pull request, no change to any ticket's state.
+Steps 4 through 7 do not run. The whole value is that it is free to run before an unattended
+night, and it is only free while it stays free of side effects.
 
-## Step 4: Dispatch each, in order
+Report all three groups — the plan is not the selected list alone:
+
+| Section | Contents |
+|---|---|
+| Would dispatch | Every `selected` id, in dispatch order |
+| Below the cap | Every `belowCap` id, in the order it would have been dispatched |
+| Excluded, and why | Every `skipped` id with its verbatim reason |
+
+Then state the **effective cap and where it came from** — the configured `batch.maxTickets`,
+or tonight's override, naming both the number and which one won. Someone reading this is
+deciding whether the cap is right; a bare "cap: 2" does not say whether that came from the
+config or from what they just typed.
+
+Then stop. A dry run ends here — there is no go-ahead to give, because nothing is waiting on
+one.
+
+**A filter failure in a dry run is a failure, not an empty plan.** Step 2 already stopped if
+`csw-batch-filter` exited non-zero; do not print three empty groups underneath it. Three
+empty groups mean "nothing was eligible tonight", which is the one thing a failed selection
+does not mean.
+
+## Step 4: Confirm the selection
+
+Show all three groups — `selected`, `belowCap`, and every `skipped` entry with its reason —
+then wait for a go-ahead. `belowCap` belongs in front of the human here: it is the only
+moment where "there were three more ready to go" can still change tonight's cap. This is the
+last human checkpoint before an unattended night — once given, Steps 5 through 7 run straight
+through with no further prompting and no further confirmation, until the morning summary
+reports what happened.
+
+## Step 5: Dispatch each, in order
 
 For each selected ticket, run **csw:work** with that ticket reference. Let it run to its hard
 stop at an open PR, then move to the next one. One worktree and one PR per ticket.
 
-## Step 5: When a ticket blocks
+## Step 6: When a ticket blocks
 
 An unattended batch has nobody to ask. So instead of stopping and waiting:
 
@@ -116,7 +173,7 @@ worth keeping, but it is not a merge candidate."
 The answer then lands in the ticket as durable context, so a re-dispatch starts from a better
 brief than the original. The loop compounds rather than merely parallelizes.
 
-## Step 6: Morning summary
+## Step 7: Morning summary
 
 Report, so the night does not have to be reconstructed by hand across the tracker:
 
@@ -125,6 +182,7 @@ Report, so the night does not have to be reconstructed by hand across the tracke
 | Dispatched | Every ticket the loop started |
 | PRs open | Ticket, PR URL, one line on what changed |
 | Blocked with questions | Ticket, the question asked, the draft PR |
+| Below the cap | Every `belowCap` id from Step 2, in order — tonight's queue, not tonight's rejects |
 | Skipped and why | Every `skipped` entry from Step 2, verbatim reason |
 
 If Step 2 failed outright, this table is not the report. Say plainly that selection failed,
@@ -146,3 +204,6 @@ Then stop. Merging the night's PRs is a morning decision, made by a human lookin
 | "The skip reasons are noise in the summary" | They are the tuning data for the next batch. Report all of them. |
 | "csw-batch-filter printed nothing, must mean no tickets were eligible" | Check the exit code first. Non-zero means selection failed — report the failure, don't dispatch nothing and call it a quiet night. |
 | "They said cap it at 6 tonight, I'll pass that through" | The override can only lower the cap. `batch.maxTickets` is the ceiling; ignore anything at or above it, and say so. |
+| "Over the cap is skipped, same table" | Different questions. `skipped` is why a ticket must not run; `belowCap` is what a bigger cap would have picked up. Merged, neither is answerable. |
+| "A dry run may as well make the worktrees, they're cheap" | A dry run has no side effects at all. No branches, no worktrees, no ticket state changes — that is the only reason it is safe to run before anything is decided. |
+| "The dry run found nothing, quiet night" | Check whether selection *failed*. Three empty groups mean nothing was eligible; a non-zero exit means nothing was evaluated. |

--- a/tests/test-csw-batch-filter.sh
+++ b/tests/test-csw-batch-filter.sh
@@ -18,6 +18,8 @@ cd "$repo" || exit 1
 
 run() { printf '%s' "$1" | "$BIN/csw-batch-filter"; }
 selected() { run "$1" | jq -c '.selected'; }
+below_cap() { run "$1" | jq -c '.belowCap'; }
+skipped_ids() { run "$1" | jq -c '[.skipped[].id]'; }
 reason_for() { run "$1" | jq -r --arg id "$2" '.skipped[] | select(.id == $id) | .reason'; }
 
 # Blocked tickets are excluded.
@@ -69,7 +71,8 @@ t='[
 ]'
 assert_eq "$(selected "$t")" '["F-2"]' "direct relation clusters two candidates"
 
-# The cap is the last filter applied, and it explains itself.
+# The cap is the last cut applied, and it is not an exclusion: what it leaves out is
+# reported in belowCap, not skipped.
 t='[
   {"id":"G-1","state":"Todo","priority":1},
   {"id":"G-2","state":"Todo","priority":1},
@@ -77,7 +80,8 @@ t='[
   {"id":"G-4","state":"Todo","priority":3}
 ]'
 assert_eq "$(selected "$t")" '["G-1","G-2","G-3"]' "batch cap of 3"
-assert_contains "$(reason_for "$t" G-4)" "batch cap" "cap reason is explicit"
+assert_eq "$(below_cap "$t")" '["G-4"]' "the ticket over the cap lands in belowCap"
+assert_eq "$(skipped_ids "$t")" '[]' "the ticket over the cap is not skipped"
 
 # Empty input is valid.
 assert_eq "$(selected '[]')" '[]' "empty input selects nothing"
@@ -147,15 +151,16 @@ t='[{"id":"NEG-1","state":"Todo","priority":1}]'
 assert_eq "$(status_of "$t")" "2" "negative maxTickets exits 2"
 assert_contains "$(stderr_of "$t")" "maxTickets" "negative maxTickets error names the key"
 
-# maxTickets: 0 is valid and meaningful — it selects nothing, and every candidate is
-# skipped with the batch-cap reason.
+# maxTickets: 0 is valid and meaningful — it selects nothing, and every candidate falls
+# below the cap. None of them was excluded, so none of them is skipped.
 write_config "$repo" <<'JSON'
 { "tracker": "linear", "batch": { "maxTickets": 0, "singleWriterLabels": ["migration"] } }
 JSON
 t='[{"id":"Z-1","state":"Todo","priority":1},{"id":"Z-2","state":"Todo","priority":2}]'
 assert_eq "$(selected "$t")" '[]' "maxTickets 0 selects nothing"
-assert_contains "$(reason_for "$t" Z-1)" "batch cap" "maxTickets 0 skips the first with the cap reason"
-assert_contains "$(reason_for "$t" Z-2)" "batch cap" "maxTickets 0 skips the second with the cap reason"
+assert_eq "$(below_cap "$t")" '["Z-1","Z-2"]' \
+  "maxTickets 0 puts every candidate below the cap, in dispatch order"
+assert_eq "$(skipped_ids "$t")" '[]' "maxTickets 0 skips nothing"
 
 # Non-list singleWriterLabels: exit 2, names the key.
 write_config "$repo" <<'JSON'
@@ -174,7 +179,8 @@ write_config "$repo" <<'JSON'
 JSON
 
 # The invariant every filter above depends on: every input ticket appears exactly
-# once across selected plus skipped. This is a permanent guard, not just a probe.
+# once across selected plus belowCap plus skipped. This is a permanent guard, not
+# just a probe.
 t='[
   {"id":"INV-1","state":"Todo","priority":1,"labels":["migration"]},
   {"id":"INV-2","state":"Todo","priority":2,"labels":["migration"]},
@@ -186,10 +192,11 @@ t='[
 ]'
 out=$(run "$t")
 in_ids=$(printf '%s' "$t" | jq -c '[.[].id] | sort')
-out_ids=$(printf '%s' "$out" | jq -c '(.selected + [.skipped[].id]) | sort')
-assert_eq "$out_ids" "$in_ids" "every ticket appears across selected+skipped, same set as the input"
-dupe_count=$(printf '%s' "$out" | jq '(.selected + [.skipped[].id]) | (length - (unique | length))')
-assert_eq "$dupe_count" "0" "no ticket appears in both selected and skipped"
+out_ids=$(printf '%s' "$out" | jq -c '(.selected + .belowCap + [.skipped[].id]) | sort')
+assert_eq "$out_ids" "$in_ids" \
+  "every ticket appears across selected+belowCap+skipped, same set as the input"
+dupe_count=$(printf '%s' "$out" | jq '(.selected + .belowCap + [.skipped[].id]) | (length - (unique | length))')
+assert_eq "$dupe_count" "0" "no ticket appears in more than one of the three groups"
 
 # --- Fix round 2: per-field type validation instead of crashing or silently ---
 # --- misreading a malformed field. ---
@@ -248,5 +255,45 @@ assert_contains "$err" "blockedBy" "string blockedBy error names the field"
 t='[{"id":"LX-1","state":"Todo","priority":1,"labels":["ok",7]}]'
 assert_eq "$(status_of "$t")" "2" "non-string element inside labels exits 2"
 assert_contains "$(stderr_of "$t")" "LX-1" "non-string list element error names the ticket id"
+
+# --- Cap overflow is reported separately from genuine exclusions ---
+
+# belowCap carries everything that passed every filter and still fell outside the cap, in
+# the order it would have been dispatched. That is the difference between "must not run
+# tonight" and "would have run with a bigger cap", which nothing downstream could tell
+# apart while both shared one `skipped` array.
+t='[
+  {"id":"CAP-1","state":"Todo","priority":4},
+  {"id":"CAP-2","state":"Todo","priority":1},
+  {"id":"CAP-3","state":"Todo","priority":3},
+  {"id":"CAP-4","state":"Todo","priority":2},
+  {"id":"CAP-5","state":"Todo","priority":3,"blockedBy":["CAP-9"]}
+]'
+assert_eq "$(selected "$t")" '["CAP-2","CAP-4","CAP-3"]' "the cap keeps the top three, in priority order"
+assert_eq "$(below_cap "$t")" '["CAP-1"]' "belowCap carries the overflow in dispatch order"
+assert_eq "$(skipped_ids "$t")" '["CAP-5"]' "skipped carries only the genuine exclusion"
+assert_contains "$(reason_for "$t" CAP-5)" "blocked by CAP-9" "the genuine exclusion keeps its reason"
+
+# No skip reason blames the cap any more. A reader scanning `skipped` has to be able to
+# trust that every entry there is a real exclusion.
+assert_eq "$(run "$t" | jq '[.skipped[] | select(.reason | test("cap"))] | length')" "0" \
+  "no skipped entry blames the cap"
+
+# belowCap is always present, so a consumer never has to tell "absent" from "empty".
+assert_eq "$(below_cap '[{"id":"UN-1","state":"Todo","priority":1}]')" '[]' \
+  "belowCap is an empty array when nothing overflows"
+assert_eq "$(below_cap '[]')" '[]' "belowCap is an empty array for empty input"
+
+# belowCap is strictly the cap's overflow: a ticket a filter genuinely rejected never
+# appears there, however far down the priority order it sits.
+t='[
+  {"id":"BC-1","state":"Todo","priority":1,"labels":["migration"]},
+  {"id":"BC-2","state":"Todo","priority":2,"labels":["migration"]},
+  {"id":"BC-3","state":"In Progress","priority":1},
+  {"id":"BC-4","state":"Todo","priority":3,"blockedBy":["BC-9"]}
+]'
+assert_eq "$(below_cap "$t")" '[]' "genuine exclusions never land in belowCap"
+assert_eq "$(run "$t" | jq -c '[.skipped[].id] | sort')" '["BC-2","BC-3","BC-4"]' \
+  "every genuine exclusion is still reported, with its reason"
 
 report

--- a/tests/test-integration.sh
+++ b/tests/test-integration.sh
@@ -80,7 +80,10 @@ assert_contains "$(reason A-4)" "cluster" "cluster filter fires"
 assert_contains "$(reason A-4)" "A-3" "cluster reason names the winner it lost to"
 assert_contains "$(reason A-6)" "single-writer" "single-writer filter fires"
 assert_contains "$(reason A-6)" "A-5" "single-writer reason names the holder"
-assert_contains "$(reason A-7)" "batch cap" "cap filter fires"
+assert_eq "$(printf '%s' "$batch_out" | jq -c '.belowCap')" '["A-7"]' \
+  "the ticket over the example config's cap is reported below the cap, not skipped"
+assert_eq "$(printf '%s' "$batch_out" | jq -c '[.skipped[].id] | sort')" '["A-1","A-4","A-6"]' \
+  "skipped carries only the three genuine exclusions"
 
 # --- Cross-tool flow: derive a branch name, create and merge it, and confirm ---
 # --- the sweep reports it. ---

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -221,4 +221,25 @@ assert_contains "$(cat "$batch")" "can only lower tonight's cap, never raise it"
 assert_contains "$(cat "$batch")" "csw-config get batch.maxTickets" \
   "batch: reads the configured cap before evaluating an override"
 
+# --- batch: the filter's three-key output, and the dry run that reads it ---
+
+# The skill has to name belowCap, because it is the group whose whole reason for existing
+# is that a reader can tell it apart from skipped. Prose that only mentions two groups
+# teaches the old shape back.
+assert_contains "$(cat "$batch")" "belowCap" "batch: names the filter's belowCap group"
+assert_contains "$(cat "$batch")" "never blames the cap" \
+  "batch: says skipped carries no cap reason"
+
+assert_contains "$(fm_field "$batch" 'argument-hint')" "--dry-run" \
+  "batch: the dry-run modifier is discoverable from the argument hint"
+assert_contains "$(cat "$batch")" '`dry-run` or `dry run`' \
+  "batch: documents the spellings a human will actually type"
+assert_contains "$(cat "$batch")" \
+  "no dispatch, no worktree, no branch, no pull request, no change to any ticket's state" \
+  "batch: a dry run is enumerated as having no side effects"
+assert_contains "$(cat "$batch")" "effective cap and where it came from" \
+  "batch: a dry run says which cap won, not just its value"
+assert_contains "$(cat "$batch")" "A filter failure in a dry run is a failure, not an empty plan" \
+  "batch: a dry run cannot launder a failed selection into a quiet night"
+
 report


### PR DESCRIPTION
`csw-batch-filter` folded two unrelated verdicts into one `skipped` array: tickets a filter genuinely rejected (blocked, not Todo, same-surface cluster, single-writer conflict) and tickets that merely fell outside `maxTickets`. Nothing downstream could tell "must not run tonight" from "would have run with a bigger cap".

## The filter

Three keys instead of two:

```json
{ "selected": [...], "belowCap": [...], "skipped": [{"id", "reason"}] }
```

- `belowCap` — passed every filter, fell outside the cap, in the order it would have been dispatched. `admitted` is already in dispatch order, so the slice boundary *is* the cap.
- `skipped` — genuine exclusions only. No `batch cap` reason any more.
- The accounting guard widens: all three groups together must contain every input ticket exactly once.

## `/csw:batch --dry-run`

Also `dry-run` and `dry run`. Runs selection and stops — no dispatch, no worktree, no branch, no PR, no ticket state change. Prints all three groups, and states the effective cap **and where it came from** (config vs. tonight's override). Composes with the cap override, so `/csw:batch 2 --dry-run` shows the cut at 2. A non-zero exit from the filter still reports as a failure, never as three empty groups.

The skill's cap override moves its own overflow to the **front** of `belowCap` rather than into the skip list — nothing excluded those tickets, and they outrank whatever the filter had already put below the cap.

## Validation

- `bash tests/run-tests.sh` — all 10 files pass (371 → 383 assertions).
- `bin/**` gate: `shellcheck --severity=warning` on the four shell executables — clean.
- CI's wider `shellcheck --severity=warning tests/*.sh $(ls bin/* | grep -v batch-filter)` — clean.
- `claude plugin validate . --strict` — Validation passed.

Every existing assertion referencing a `batch cap` skip reason moved to `belowCap` rather than being deleted. New assertions were proven to bite: against the pre-change tool and skill they fail 10 (filter), 2 (integration), and 7 (skills).

Closes #71