### PR TITLE
feat: define the interactive modifier on /csw:work (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ go for merge                # merge: CI gate, merge commit, chains into cleanup
 autonomously test-first, validates, and opens a PR. Then it stops. Hold-for-review is a hard
 stop, not a checkpoint to talk past.
 
+```
+/csw:work ENG-1088 interactive
+```
+
+Same dispatch, planned out loud. It brainstorms the ticket first, surfaces the questions, and
+waits for your answers before it writes a plan — for the tickets that are vague, or where the
+approach has more than one defensible shape. Everything after planning is unchanged: same
+validation, same gates, same PR, same hard stop. A word that is neither this nor nothing gets
+named back and asked about rather than quietly dropped.
+
 **Merge** is natural language, not a command — `go for merge`, `diffs look good`, `merge it`
 — because it is said mid-conversation where a slash command is friction. An ambiguous "looks
 good" earns a clarifying question rather than a merge. CI red stops it.
@@ -101,6 +111,7 @@ A different project is a config file, not a fork. Full reference:
 | Command | Phase | Invocation |
 |---|---|---|
 | `/csw:work <ticket>` | Dispatch | Command, or "work ENG-1088" |
+| `/csw:work <ticket> interactive` | Dispatch | Brainstorms first, then the same run |
 | `/csw:merge` | Merge | Usually natural language: "go for merge" |
 | `/csw:cleanup` | Cleanup | Usually automatic, chained from merge |
 | `/csw:batch` | Nightly loop | Command only — never inferred |

--- a/skills/batch/SKILL.md
+++ b/skills/batch/SKILL.md
@@ -149,8 +149,14 @@ reports what happened.
 
 ## Step 5: Dispatch each, in order
 
-For each selected ticket, run **csw:work** with that ticket reference. Let it run to its hard
-stop at an open PR, then move to the next one. One worktree and one PR per ticket.
+For each selected ticket, run **csw:work** with the ticket reference and nothing else. Let it
+run to its hard stop at an open PR, then move to the next one. One worktree and one PR per
+ticket.
+
+Nothing else, because `csw:work` takes an `interactive` modifier that brainstorms the ticket
+and waits for a human to answer. At 3am there is nobody to answer, and a ticket parked on an
+unanswered question is a night that stops on the first one rather than working the rest. A
+ticket that genuinely needs the conversation is a ticket for tomorrow, dispatched by hand.
 
 ## Step 6: When a ticket blocks
 

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: work
-description: Dispatch a tracker ticket into an isolated worktree and drive it autonomously to an open pull request, then stop for review. Use when asked to work a ticket end-to-end without supervision.
-when_to_use: "/csw:work 1088", "work ENG-1088", "work 1088 autonomous to PR then hold for review", "take ENG-1088 to a PR"
-argument-hint: "[ticket-ref]"
+description: Dispatch a tracker ticket into an isolated worktree and drive it autonomously to an open pull request, then stop for review. Pass `interactive` to brainstorm the ticket with a human before planning it. Use when asked to work a ticket end-to-end.
+when_to_use: "/csw:work 1088", "work ENG-1088", "work 1088 autonomous to PR then hold for review", "take ENG-1088 to a PR", "/csw:work 1088 interactive"
+argument-hint: "[ticket-ref] [interactive]"
 ---
 
 # Work a ticket to a pull request
 
 **Announce at start:** "Using csw:work to take <ticket> to a pull request."
 
-Ticket reference: $ARGUMENTS
+Invocation: $ARGUMENTS
 
 ## Step 0: Read the config
 
@@ -22,16 +22,36 @@ If `csw-config path` prints nothing, this repo has no `.claude/csw.json`. Say so
 defaults you are about to use, and ask whether to continue or write a config first. Do not
 silently guess a validate command.
 
-## Step 1: Resolve the ticket
+## Step 1: Resolve the ticket, and the modifier
+
+The invocation is a ticket reference, optionally followed by one modifier word. Split it on
+whitespace: the first token is the reference, whatever follows it is the modifier.
 
 ```bash
-csw-ticket normalize "<the reference from the invocation>"
+csw-ticket normalize "<the first token of the invocation>"
 ```
 
 If the invocation carried no reference, ask which ticket. Do not pick one.
 
 If normalisation exits non-zero, report its message and stop — a mistyped reference is
 exactly the failure this command exists to prevent.
+
+Then read the modifier:
+
+- **`interactive`** — run **superpowers:brainstorming** against the ticket before the Step 5
+  chain. Surface the questions and wait for the answers. Do not run unattended. This is the
+  flavour someone reaches for when the ticket is vague, or when the approach has more than one
+  defensible shape; answering your own questions is exactly the thing it exists to prevent.
+- **No modifier** — autonomous, exactly as the rest of this skill describes. Brainstorming is
+  skipped because the ticket is the agreed brief.
+- **An unrecognised modifier is not ignored.** Say what was passed, say it is not recognised,
+  and ask whether to proceed autonomously — then wait. Silently discarding a word someone
+  deliberately typed is how a dispatch does something other than what was asked, and the word
+  they were reaching for may well have been `interactive`.
+
+`interactive` changes only how the work is planned. Steps 6 through 9 are untouched: the same
+validation, the same gates, the same pull request, the same hard stop. An interactive run
+still ends at an open pull request and still never merges.
 
 ## Step 2: Read the ticket and claim it
 
@@ -77,8 +97,10 @@ after confirming that directory is gitignored.
 
 Run the superpowers chain in autonomous mode:
 
-1. **superpowers:writing-plans** — the ticket is the spec. Skip brainstorming: an unattended
-   dispatch has nobody to brainstorm with, and the ticket is the agreed brief.
+1. **superpowers:writing-plans** — the ticket is the spec, and brainstorming is skipped
+   unless this run is interactive: an unattended dispatch has nobody to brainstorm with, and
+   the ticket is the agreed brief. On an interactive run Step 1 already brainstormed, and the
+   answers it surfaced are part of the spec alongside the ticket.
 2. **superpowers:executing-plans** — execute it.
 3. **superpowers:test-driven-development** — inside every task. Test first, always.
 
@@ -87,6 +109,10 @@ are a strong recommendation, not a hard dependency.
 
 Autonomous means: make the ordinary judgment calls yourself, do not stop to confirm each
 step. It does not mean skipping the stop in Step 8.
+
+An interactive run is autonomous from here too. The questions were asked in Step 1; once they
+are answered, plan, execute, and validate the same way — do not turn the rest of the run into
+a series of confirmations.
 
 ## Step 6: Validate
 
@@ -182,3 +208,6 @@ are actually asking to be merged.
 | "I'll create the worktree with git, it's faster" | Use EnterWorktree. Bypassing it strands state the harness cannot clean up. |
 | "The title tells me enough about the ticket" | Read the description. The ordering constraints are in the prose. |
 | "No config file, I'll infer the validate command" | Ask. A wrong validate command means a green run that proves nothing. |
+| "They typed a word I don't recognise, I'll get on with the ticket" | An unrecognised modifier is a question, not noise. Name it back and ask. |
+| "It's interactive, so someone is watching — I can merge it" | `interactive` changes planning only. Step 8 is the same hard stop. |
+| "It's interactive, I'll confirm each step as I go" | The questions belong in Step 1. After that it runs like any other dispatch. |

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -102,6 +102,47 @@ else
   PASSES=$((PASSES + 1))
 fi
 
+# --- work: the interactive modifier, and everything it does not change ---
+
+# The word has to be discoverable from the hint, or the only people who type it are the
+# ones who already read the skill — and they are not who the ambiguity bit.
+assert_contains "$(fm_field "$work" 'argument-hint')" "interactive" \
+  "work: the interactive modifier is discoverable from the argument hint"
+assert_contains "$(cat "$work")" "superpowers:brainstorming" \
+  "work: interactive brainstorms the ticket before planning it"
+assert_contains "$(cat "$work")" "wait for the answers" \
+  "work: an interactive run waits for answers instead of proceeding unattended"
+
+# Step 5 skips brainstorming because nobody is there to brainstorm with. On an interactive
+# run somebody is, so the skip has to be conditional rather than absolute — an unconditional
+# "skip brainstorming" in Step 5 silently undoes what Step 1 was asked to do.
+assert_contains "$(cat "$work")" "unless this run is interactive" \
+  "work: Step 5's skip-brainstorming rule yields to an interactive run"
+
+# Silently discarding a word someone deliberately typed is how a dispatch does something
+# other than what was asked. All three of these have to be present: what was passed, that
+# it is not recognised, and the question.
+assert_contains "$(cat "$work")" "An unrecognised modifier is not ignored" \
+  "work: an unrecognised modifier is never silently discarded"
+assert_contains "$(cat "$work")" "say it is not recognised" \
+  "work: an unrecognised modifier is named back and called unrecognised"
+
+# interactive changes how the work is planned and nothing else. If it were read as
+# "a human is watching, so the usual rules are softer", it would erode the one guarantee
+# every other step in this skill exists to hold.
+assert_contains "$(cat "$work")" "changes only how the work is planned" \
+  "work: interactive leaves validation, gates and the PR untouched"
+assert_contains "$(cat "$work")" "still ends at an open pull request and still never merges" \
+  "work: an interactive run stops at Step 8 like any other"
+
+# Red flags are where an agent looks when it is about to rationalise, so both failure
+# modes have to be answered there too, not only in the step prose.
+work_red_flags=$(sed -n '/^## Red flags/,$p' "$work")
+assert_contains "$work_red_flags" "modifier" \
+  "work: red flags catch a modifier being waved through"
+assert_contains "$work_red_flags" "interactive" \
+  "work: red flags deny that interactive relaxes the hard stop"
+
 # --- merge: never squash, always check CI, always chain into cleanup ---
 merge="$SKILLS/merge/SKILL.md"
 assert_contains "$(cat "$merge")" "gh pr checks" "merge: checks CI"
@@ -214,6 +255,11 @@ else
   FAILURES=$((FAILURES + 1))
   printf 'FAIL batch: warns about the blocking-relation prerequisite\n' >&2
 fi
+# csw:work now takes an `interactive` modifier, which brainstorms and waits for answers.
+# A batch runs overnight with nobody to answer, so the dispatch has to say the reference
+# goes over on its own.
+assert_contains "$(cat "$batch")" "the ticket reference and nothing else" \
+  "batch: dispatches csw:work with no modifier, so no ticket can stop for answers"
 assert_contains "$(cat "$batch")" "A failed selection is never an empty selection" \
   "batch: a filter failure is reported distinctly from an empty batch"
 assert_contains "$(cat "$batch")" "can only lower tonight's cap, never raise it" \


### PR DESCRIPTION
`/csw:work ENG-1088 interactive` was undefined behaviour: `$ARGUMENTS` expands to the whole string, so the trailing word sat in context unexplained and it was unpredictable whether it overrode the skill's autonomous directive.

## What changed

**`skills/work/SKILL.md`**
- `argument-hint` is now `"[ticket-ref] [interactive]"`; the `$ARGUMENTS` line reads `Invocation:` rather than `Ticket reference:`, since it carries both.
- Step 1 splits the invocation and defines all three cases: `interactive` runs `superpowers:brainstorming` first and waits for answers; no modifier is autonomous exactly as before; an unrecognised modifier is named back, called unrecognised, and asked about rather than dropped.
- Step 5's skip-brainstorming rule now yields to an interactive run, and says the run is autonomous again once the questions are answered — not a series of confirmations.
- Three red flags: a discarded modifier, "it's interactive so I can merge", and "it's interactive so I'll confirm each step".
- Validation, gates, the PR and the Step 8 hard stop are untouched. An interactive run still ends at an open PR and still never merges.

**`skills/batch/SKILL.md`** — Step 5 now dispatches `csw:work` with the ticket reference *and nothing else*. This is the one place the new modifier could leak into an unattended run: at 3am nobody answers a brainstorming question, and a ticket parked on one stops the night on its first ticket.

**`README.md`** — an `/csw:work <ticket> interactive` block alongside the existing dispatch example, plus a Commands table row.

**`tests/test-skills.sh`** — 10 new assertions on the work skill, 1 on batch. All 11 were run against the pre-change skills and fail there.

## Testing

`bash tests/run-tests.sh` is green (107 passed in the skills suite). `csw-gates --files` over the committed diff plus the working tree triggers nothing — the only configured gate is `bin/**`, and this touches no scripts.

Worth a human eye: this is skill prose, so the real test is whether an agent reading Step 1 actually stops and asks on `/csw:work 72 yolo` instead of shrugging it off, and whether `/csw:work 72 interactive` brainstorms without turning the rest of the run into confirmations. CI cannot cover either.

Closes #72