### PR TITLE
fix: dispatch each batch ticket to a fresh subagent (#78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ something reported unprompted. Branch cleanup never asks. Closing a ticket alway
 ```
 
 Pulls Todo tickets, excludes what cannot safely run tonight, and dispatches the rest — one
-worktree and one PR each — then leaves a morning summary. Three filters, because one is not
-enough:
+worktree and one PR each — then leaves a morning summary. Every ticket runs in a subagent of
+its own, so it gets its own context as well as its own worktree: nothing ticket one planned,
+tried, or abandoned is still in the room when ticket two starts. Three filters, because one is
+not enough:
 
 - **Blocked tickets**, which only works if your tracker actually records blocking relations.
 - **Contended global resources.** Two migration-adding tickets each write the next number in

--- a/skills/batch/SKILL.md
+++ b/skills/batch/SKILL.md
@@ -147,25 +147,74 @@ last human checkpoint before an unattended night — once given, Steps 5 through
 through with no further prompting and no further confirmation, until the morning summary
 reports what happened.
 
-## Step 5: Dispatch each, in order
+## Step 5: Dispatch each to a fresh subagent, in order
 
-For each selected ticket, run **csw:work** with the ticket reference and nothing else. Let it
-run to its hard stop at an open PR, then move to the next one. One worktree and one PR per
-ticket.
+Every selected ticket goes to a **fresh subagent** of its own, dispatched in order, each
+running `csw:work` to its hard stop at an open PR. One subagent, one worktree, one PR per
+ticket. **Never run `csw:work` in this session.**
 
-Nothing else, because `csw:work` takes an `interactive` modifier that brainstorms the ticket
-and waits for a human to answer. At 3am there is nobody to answer, and a ticket parked on an
-unanswered question is a night that stops on the first one rather than working the rest. A
-ticket that genuinely needs the conversation is a ticket for tomorrow, dispatched by hand.
+This session holds the loop and nothing else: the three groups from Step 2, the row each
+dispatch returns, and the morning summary. It must never hold a ticket's plan, its diff, or the
+approaches it tried and abandoned — because whatever it holds, the next ticket inherits.
+Isolated worktrees driven from one shared context are not isolated dispatches: ticket two is
+biased by an approach chosen for ticket one, and a dead end explored at 11pm is still sitting
+in context at 2am when nobody is watching. The subagent is the programmatic equivalent of
+clearing context before each dispatch, which is the discipline this whole workflow rests on.
 
-## Step 6: When a ticket blocks
+### The dispatch
 
-An unattended batch has nobody to ask. So instead of stopping and waiting:
+- **A fresh subagent per ticket.** Not a fork: a fork inherits the parent conversation
+  wholesale, which is the exact contamination being removed here. It would look like isolation
+  and provide none.
+- **The brief is the ticket reference and nothing else.** `csw:work` Step 2 reads the ticket
+  from the tracker itself, so a reference is a complete brief. Anything else you add is context
+  from a different ticket.
+- **Synchronously, one at a time, in dispatch order.** The controller needs each result before
+  it moves on; a night whose dispatches all land at once is a morning that cannot attribute
+  anything.
+- **With no worktree isolation on the subagent.** `csw:work` Step 4 creates the worktree itself,
+  on the branch `csw-ticket branch` derives from the ticket. A subagent handed an isolated
+  worktree at launch is already inside one and cannot create that branch — it would work in an
+  auto-named temporary worktree instead, on a branch name that nothing downstream (the PR title,
+  `csw:merge`, `csw:cleanup`) knows how to find.
 
-1. Write the question as a comment on the ticket.
-2. Push a **draft** PR carrying the work so far (`gh pr create --draft`), referencing it.
-3. Leave the ticket In Progress.
-4. Continue to the next ticket.
+`csw:work` is reachable from inside a subagent because it sets no `disable-model-invocation`:
+the subagent invokes it through the Skill tool by name, and it can equally be preloaded into a
+subagent definition's `skills` field. Nothing extra has to be installed for this to work.
+
+The reference goes over on its own for a second reason too. `csw:work` takes an `interactive`
+modifier that brainstorms the ticket and waits for a human to answer, and at 3am there is
+nobody to answer — a ticket parked on an unanswered question is a night that stops on the first
+one rather than working the rest. A ticket that genuinely needs the conversation is a ticket for
+tomorrow, dispatched by hand. A subagent cannot ask the user anything even if it wanted to, but
+do not lean on that: pass the reference alone and the question never arises.
+
+### The report contract
+
+Each subagent returns one structured result and nothing else — no transcript, no plan, no diff:
+
+| Field | Contents |
+|---|---|
+| `ticket` | The reference that was dispatched |
+| `outcome` | `pr`, `draft`, or `failed` |
+| `pr` | The pull request URL, or none if it never got that far |
+| `summary` | One line on what changed |
+| `blocker` | For `draft` and `failed`: the question asked, or what stopped it |
+
+That row is all the controller keeps. It is what Step 7 assembles the morning summary from,
+which is why the summary is built out of results rather than reconstructed from a transcript.
+A subagent that returns prose instead has handed back the transcript problem; record what you
+can from it, note that it did not honour the contract, and carry on.
+
+## Step 6: When a ticket blocks or fails
+
+An unattended batch has nobody to ask. So instead of stopping and waiting, the subagent working
+the ticket:
+
+1. Writes the question as a comment on the ticket.
+2. Pushes a **draft** PR carrying the work so far (`gh pr create --draft`), referencing it.
+3. Leaves the ticket In Progress.
+4. Returns `outcome: draft` with the question as its `blocker`.
 
 Draft is load-bearing: preview automation filters drafts out, so blocked work survives and
 stays reviewable without polluting the environment used to review the PRs that finished. In
@@ -179,15 +228,25 @@ worth keeping, but it is not a merge candidate."
 The answer then lands in the ticket as durable context, so a re-dispatch starts from a better
 brief than the original. The loop compounds rather than merely parallelizes.
 
+**A subagent that fails outright is one row in the summary, not the end of the night.** It
+returned `failed`, or it errored, or it came back with nothing usable at all. Record what you
+have — the ticket, `failed`, and whatever it said — and dispatch the next ticket. Do not
+re-dispatch the one that failed, and do not try to finish its work here: this session has no
+worktree, no context, and no business acquiring either. Failure isolation is the point of
+dispatching this way, and it is only real if the loop actually keeps going.
+
 ## Step 7: Morning summary
 
-Report, so the night does not have to be reconstructed by hand across the tracker:
+Assemble it from the rows Step 5 collected — one per dispatched ticket — plus the three groups
+Step 2 returned. That is the whole input, and it is why the night does not have to be
+reconstructed by hand across the tracker or read back out of a transcript:
 
 | Section | Contents |
 |---|---|
 | Dispatched | Every ticket the loop started |
-| PRs open | Ticket, PR URL, one line on what changed |
-| Blocked with questions | Ticket, the question asked, the draft PR |
+| PRs open | Ticket, PR URL, one line on what changed — the `pr` rows |
+| Blocked with questions | Ticket, the question asked, the draft PR — the `draft` rows |
+| Failed | Ticket and what came back — the `failed` rows, if any |
 | Below the cap | Every `belowCap` id from Step 2, in order — tonight's queue, not tonight's rejects |
 | Skipped and why | Every `skipped` entry from Step 2, verbatim reason |
 
@@ -213,3 +272,8 @@ Then stop. Merging the night's PRs is a morning decision, made by a human lookin
 | "Over the cap is skipped, same table" | Different questions. `skipped` is why a ticket must not run; `belowCap` is what a bigger cap would have picked up. Merged, neither is answerable. |
 | "A dry run may as well make the worktrees, they're cheap" | A dry run has no side effects at all. No branches, no worktrees, no ticket state changes — that is the only reason it is safe to run before anything is decided. |
 | "The dry run found nothing, quiet night" | Check whether selection *failed*. Three empty groups mean nothing was eligible; a non-zero exit means nothing was evaluated. |
+| "I'll just run csw:work here, it's one extra ticket" | Then this session carries that ticket into the next one. Every dispatch is a fresh subagent, without exception. |
+| "A fork keeps the context I need" | The context you keep is the contamination. A fork inherits everything; a subagent inherits the reference. |
+| "Give the subagent an isolated worktree so it starts clean" | `csw:work` Step 4 makes the worktree, on the branch derived from the ticket. Pre-isolating it strands the work on a name nothing downstream can find. |
+| "The subagent stalled, I'll pick up where it left off" | One failure is one row in the summary. Record it and dispatch the next ticket. |
+| "I'll paste its transcript into the summary" | The summary is assembled from returned rows. A transcript in the summary is the problem the subagents exist to remove. |

--- a/tests/test-docs.sh
+++ b/tests/test-docs.sh
@@ -15,6 +15,11 @@ fi
 for phrase in "not yours" "unmaintained" "/csw:work" "/csw:merge" "/csw:cleanup" "/csw:batch"; do
   assert_contains "$(cat "$readme")" "$phrase" "README mentions $phrase"
 done
+# A batch's isolation is per ticket in both senses — its own worktree and its own context —
+# and the second one is the part a reader cannot infer from "one PR each".
+assert_contains "$(cat "$readme")" "its own context" \
+  "README says a batch isolates each ticket's context, not only its worktree"
+
 for gone in "/csw:spec" "/csw:plan" "/csw:build" "/csw:ship"; do
   if grep -q -- "$gone" "$readme"; then
     FAILURES=$((FAILURES + 1)); printf 'FAIL README still advertises %s\n' "$gone" >&2

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -262,6 +262,48 @@ assert_contains "$(cat "$batch")" "the ticket reference and nothing else" \
   "batch: dispatches csw:work with no modifier, so no ticket can stop for answers"
 assert_contains "$(cat "$batch")" "A failed selection is never an empty selection" \
   "batch: a filter failure is reported distinctly from an empty batch"
+
+# --- batch: one fresh subagent per ticket ---
+#
+# The loop used to run every csw:work dispatch in the controlling session, so ticket two
+# inherited ticket one's plan, its diff and its dead ends. Worktrees were isolated; the mind
+# driving them was not. Each ticket now gets a subagent, which is the programmatic equivalent
+# of clearing context between dispatches.
+assert_contains "$(cat "$batch")" "fresh subagent" \
+  "batch: each ticket is dispatched to a subagent of its own"
+assert_contains "$(cat "$batch")" "Never run \`csw:work\` in this session" \
+  "batch: the controlling session never does a ticket's work itself"
+# A fork inherits the whole parent conversation, which is precisely the flaw being fixed —
+# it would look like a subagent and contaminate exactly as badly.
+assert_contains "$(cat "$batch")" "Not a fork" \
+  "batch: says why a fork is not the isolation being asked for"
+# csw:work Step 4 creates the worktree on a branch csw-ticket derives from the ticket. A
+# subagent handed worktree isolation is already in one and cannot create that branch.
+assert_contains "$(cat "$batch")" "no worktree isolation" \
+  "batch: the dispatch leaves the worktree to csw:work rather than pre-isolating the subagent"
+assert_contains "$(cat "$batch")" "creates the worktree itself" \
+  "batch: names which step owns the worktree, so the dispatch does not duplicate it"
+# The controller assembles the morning summary out of returned rows. If a subagent hands back
+# prose, the summary is reconstructed from a transcript again — the thing this change removes.
+assert_contains "$(cat "$batch")" "report contract" \
+  "batch: each subagent returns a structured result, not a narrative"
+assert_contains "$(cat "$batch")" "one row in the summary, not the end of the night" \
+  "batch: one failed ticket does not stop the loop"
+# Skill reachability is the one thing that makes this dispatch shape work at all: csw:work
+# sets no disable-model-invocation, so a subagent can invoke it through the Skill tool.
+# Matched on the sentence rather than the bare field name, which batch's own frontmatter
+# already carries and which would therefore pass without the explanation being written.
+assert_contains "$(cat "$batch")" "sets no \`disable-model-invocation\`" \
+  "batch: records why csw:work is reachable from inside a subagent"
+# The summary is now assembled from the rows Step 5 collected, not recovered from the night's
+# transcript. Saying so in Step 7 is what stops the controller reaching for a transcript it
+# deliberately no longer has.
+batch_summary=$(sed -n '/^## Step 7/,/^## Red flags/p' "$batch")
+assert_contains "$batch_summary" "rows Step 5 collected" \
+  "batch: the morning summary is assembled from returned rows, not from a transcript"
+batch_red_flags=$(sed -n '/^## Red flags/,$p' "$batch")
+assert_contains "$batch_red_flags" "subagent" \
+  "batch: red flags catch a dispatch run in the controlling session"
 assert_contains "$(cat "$batch")" "can only lower tonight's cap, never raise it" \
   "batch: the cap override is documented as lower-only"
 assert_contains "$(cat "$batch")" "csw-config get batch.maxTickets" \


### PR DESCRIPTION
`/csw:batch` Step 4 ran every `csw:work` dispatch in the controlling session. Ticket two
inherited ticket one's plan, its diff and its rejected approaches; ticket four inherited all
three. The design handed each ticket an isolated *worktree* and a shared *mind* — the exact
opposite of the clear-before-every-dispatch discipline the rest of the workflow rests on.

## What changed

- **Step 5 dispatches each ticket to a fresh subagent**, synchronously and in order, briefed
  with the ticket reference and nothing else. Not a fork — a fork inherits the parent
  conversation wholesale and would look like isolation while providing none.
- **The dispatch passes no worktree isolation.** `csw:work` Step 4 creates the worktree itself,
  on the branch `csw-ticket branch` derives from the ticket. A pre-isolated subagent is already
  inside a worktree, cannot create that branch, and would strand the work on an auto-named
  branch that neither the PR title, `csw:merge`, nor `csw:cleanup` can find.
- **A report contract**: each subagent returns one row — `ticket`, `outcome` (`pr`/`draft`/`failed`),
  `pr`, `summary`, `blocker`. That row is all the controller keeps.
- **Step 7 assembles the morning summary from those rows**, plus Step 2's three groups. It is no
  longer reconstructed from a transcript, and it now has a `failed` section.
- **Step 6 makes failure isolation explicit**: a subagent that fails is one row in the summary,
  not the end of the night. No re-dispatch, and no finishing its work in the controlling session.
- Five red flags covering the ways an agent would rationalise its way back to the old shape.
- README says the isolation is per-context as well as per-worktree.

## The two questions the ticket asked to verify

Both resolve against the current Claude Code subagent documentation, and both answers are now
recorded in the skill rather than left as folklore:

- **Skill availability.** `csw:work` sets no `disable-model-invocation`, so a subagent invokes
  it through the Skill tool by name, and it can equally be preloaded through a subagent
  definition's `skills` field. Nothing extra needs installing.
- **`EnterWorktree` from a subagent.** Subagents keep `EnterWorktree`/`ExitWorktree` under both
  tool filters and start in the parent's working directory, so the subagent creates its own
  worktree — which is why the controller must *not* pre-isolate it.

A third answer fell out along the way: `AskUserQuestion` is removed from every subagent, so the
"no `interactive` modifier at 3am" rule is now structurally enforced as well as stated. The skill
says not to lean on that and to pass the reference alone regardless.

## Testing

TDD throughout — ten new assertions in `tests/test-skills.sh` and one in `tests/test-docs.sh`,
each watched fail before the prose was written. One initially passed by accident (`disable-model-invocation`
appears in batch's own frontmatter) and was tightened to match the explanatory sentence instead.

`bash tests/run-tests.sh` — all files pass, 117 in `test-skills.sh`. `csw-gates --files` over the
committed diff and the working tree triggers nothing; the only configured gate is on `bin/**`,
which this branch does not touch.

## Worth a human eye

This is a skill-prose change, so the tests only prove the load-bearing sentences are present —
they cannot prove an agent reading it will actually dispatch this way. The real test is a live
`/csw:batch` run against two or more tickets, checking that the second subagent shows no
awareness of the first and that each lands on a `<type>/<ticket>-<slug>` branch rather than an
auto-named worktree branch.

`docs/design.md` Phase 4 still describes the loop as "a sorted for-loop over phase 1" and was
deliberately left alone — it is a dated, superseded design record, not the living spec.

Closes #78