### PR TITLE
feat: add /csw:prep, a spec-only pass before the batch (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,20 @@ out*.
 ## The three phases
 
 ```
+/csw:prep ENG-1088          # optional: spec it, ask the questions, touch nothing
 /csw:work ENG-1088          # dispatch: worktree, autonomous implementation, PR, stop
   ... you review the diff ...
 go for merge                # merge: CI gate, merge commit, chains into cleanup
                             # cleanup: worktree gone, branches gone, sweep reported
 ```
+
+**Prep** is the optional pass in front of the dispatch. It reads the ticket, brainstorms it for
+the questions that would stop an unattended run, notes anything the ticket asserts that the
+codebase contradicts, and writes all of it to **one ticket comment** marked `**CSW prep**`. It
+opens no worktree, no branch and no PR, and leaves the ticket in Todo. Dispatch reads that
+comment back as part of the brief — answers in the thread are decisions, and questions still
+unanswered send the run to a draft PR instead of a guess. Without it the loop only learns after
+a failure, at the cost of one wasted dispatch per question.
 
 **Dispatch** reads the ticket, sets it In Progress, opens a worktree, runs the work
 autonomously test-first, validates, and opens a PR. Then it stops. Hold-for-review is a hard
@@ -59,6 +68,9 @@ not enough:
   most one per batch.
 - **Same-surface clusters.** Tickets that share related-issue links tend to land in each
   other's copy even when they touch different files. Highest priority per cluster.
+
+Prepped tickets dispatch better, but the loop does not require prep and does not skip tickets
+that lack it.
 
 Three or four tickets a night, not the whole column — the cap comes from review, not from the
 loop. Anything that does not reach merge-ready is left as a **draft** PR with a question on
@@ -112,6 +124,7 @@ A different project is a config file, not a fork. Full reference:
 
 | Command | Phase | Invocation |
 |---|---|---|
+| `/csw:prep <ticket>` | Before dispatch | Optional — spec only, no side effects |
 | `/csw:work <ticket>` | Dispatch | Command, or "work ENG-1088" |
 | `/csw:work <ticket> interactive` | Dispatch | Brainstorms first, then the same run |
 | `/csw:merge` | Merge | Usually natural language: "go for merge" |

--- a/skills/batch/SKILL.md
+++ b/skills/batch/SKILL.md
@@ -31,6 +31,12 @@ four links each, the dependency information exists but is in the wrong field and
 first, and if `blockedBy` is empty across the board, say so and stop rather than dispatching
 a batch whose ordering constraints are invisible.
 
+**Prepped tickets dispatch better.** `/csw:prep <ticket>` leaves a spec and its open questions
+on the ticket, and `csw:work` Step 2 reads them, so a question that would have cost a whole
+dispatch to discover is already answered when the loop reaches it. It is not required, and this
+loop **does not skip unprepped** tickets — an optional command that silently became a gate
+would be a new manual step in front of every ticket in the column.
+
 ## Step 1: Pull the candidates
 
 Read every Todo ticket from the tracker named by `csw-config get tracker` and shape it into

--- a/skills/prep/SKILL.md
+++ b/skills/prep/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: prep
+description: Spec a ticket before it is dispatched. Brainstorms it for the questions that must be answered before it can run unattended, then leaves a first-pass spec as one ticket comment. No worktree, no branch, no pull request, and the ticket stays where it was.
+when_to_use: "/csw:prep 1088", "prep ENG-1088", "spec ENG-1088 before tonight's batch", "is this ticket ready to dispatch?"
+argument-hint: "[ticket-ref]"
+---
+
+# Prep a ticket for dispatch
+
+**Announce at start:** "Using csw:prep to spec <ticket> without touching the repo."
+
+Invocation: $ARGUMENTS
+
+A batch loop only compounds *after* a failure: a ticket blocks, the question lands on the
+ticket, and the next dispatch starts from a better brief — so one wasted dispatch is the price
+of every question discovered. Prep moves that discovery in front of the dispatch, where it
+costs a comment instead of a night.
+
+Prep does not implement anything, and it does not decide anything a human should. It reads,
+it asks, and it writes one comment.
+
+## Step 0: Read the config
+
+```bash
+csw-config json
+csw-config path
+```
+
+If `csw-config path` prints nothing, this repo has no `.claude/csw.json`. Say so and show the
+defaults you are about to use. Prep runs nothing destructive, so this is a note rather than a
+stop — but `tracker` is the one key it genuinely needs, because it decides where the comment
+goes.
+
+## Step 1: Resolve the ticket
+
+```bash
+csw-ticket normalize "<the reference from the invocation>"
+```
+
+If the invocation carried no reference, ask which ticket. Do not pick one.
+
+If normalisation exits non-zero, report its message and stop. Prepping the wrong ticket is
+worse than prepping none: the comment lands somewhere a later dispatch will read it as its
+brief.
+
+## Step 2: Read the ticket — and only read it
+
+Read it from the tracker named by `csw-config get tracker`:
+
+- `linear` — the Linear MCP tools. Fetch the issue and its existing comments.
+- `github` — `gh issue view <number> --json title,body,labels` and
+  `gh issue view <number> --comments`.
+- `none` — ask for the ticket text.
+
+Read the **whole** description, not the title. Ordering constraints and "replace, do not
+delete" style requirements live in prose and are invisible to structured queries — and those
+are exactly the requirements a dispatch discovers too late.
+
+**Do not claim it.** `csw:work` Step 2 moves the ticket to In Progress because it is about to
+do the work; prep is not. A prepped ticket that left Todo is a ticket the batch loop no longer
+pulls, which removes it from the very column prep exists to improve.
+
+Read the existing comments too, and read them before brainstorming rather than after. A
+question already asked and answered in the thread is a decision, not an open question, and
+re-asking it in the prep comment tells the next dispatch to go and re-litigate it. If a prior
+`**CSW prep**` comment is already there, this run supersedes it: say which questions it left
+unanswered and do not simply repeat the ones that have since been settled.
+
+## Step 3: Brainstorm it, in surface-the-questions mode
+
+Run **superpowers:brainstorming** against the ticket.
+
+Its usual mode designs the implementation. This is not that mode: prep runs in
+**surface-the-questions mode**, and the difference is the whole point of the command. The
+design belongs to the dispatch, which will have a worktree to try it in and tests to find out
+whether it was right. What prep produces is the set of things that dispatch would otherwise
+stop on.
+
+You may read anything in the repo. Reading is not a side effect. Check what the ticket asserts
+against what the code actually does — a ticket that names a file, a flag, or a function that
+has since moved is a dispatch that will spend its run discovering that.
+
+What to come out with:
+
+- **A first-pass spec.** What the change is, in the terms the codebase actually uses.
+- **The open questions** — specifically the ones that must be answered before this can run
+  *unattended*. That is the bar. "Which of these two names is nicer" does not stop a dispatch;
+  "does this replace the existing path or sit alongside it" does.
+- **Contradictions.** Anything the ticket asserts that the codebase contradicts, quoted from
+  both sides so a human can adjudicate it without going and looking.
+
+If the superpowers skills are not installed, say so once and do the same work by hand. The
+skill is a strong recommendation, not a hard dependency.
+
+## Step 4: Write one comment
+
+**One comment**, on the ticket, prefixed with the marker exactly:
+
+```bash
+# tracker: github
+gh issue comment <number> --body "$body"
+```
+
+For `linear`, the same body through the Linear MCP comment tool. For `none`, print it and say
+where it should be pasted.
+
+The body:
+
+```markdown
+**CSW prep**
+
+## First-pass spec
+<what the change is, in the codebase's own terms>
+
+## Open questions
+1. <a question that would stop an unattended dispatch>
+2. <another>
+
+## What the ticket asserts that the codebase contradicts
+- <claim> — <what is actually there, with the path>
+```
+
+The marker `**CSW prep**` is load-bearing and must be exact. `csw:work` Step 2 searches the
+comments for that string; a comment that says "Prep notes" instead is a comment nothing will
+ever read back.
+
+**One comment, not a thread.** Answers arrive as replies underneath it, and a human scanning
+the ticket has to be able to tell prep's questions from prep's own restatements of them. Three
+comments from prep means the answers interleave with the questions and nobody can tell which
+is which.
+
+Leave the questions genuinely open. Prep answering its own questions is the failure this
+command exists to prevent — an unattended dispatch will then treat the guess as the brief.
+
+## Step 5: Stop
+
+Report what you wrote and stop.
+
+**No worktree, no branch, no pull request, no validation run**, no commit, and no change to
+the ticket's state — it **stays in Todo** so the batch loop still picks it up. That is prep's
+whole contract, and it is the only reason it is safe to run against a column of tickets before
+anything about them has been decided.
+
+Do not continue into `csw:work`. Prep ending is the point at which a human reads the questions;
+answering them is not prep's job, and neither is starting the work while nobody has.
+
+## Red flags
+
+| Thought | Reality |
+|---|---|
+| "I know what they meant, I'll answer the question myself" | Then the dispatch inherits your guess as the brief. Leave it open. |
+| "I've read enough to just start it — I'll open the worktree" | Prep has no worktree. If it is ready to run, dispatch it with `csw:work`. |
+| "Set it In Progress so nobody double-prepares it" | Todo is what the batch loop pulls. Claiming it un-batches it. |
+| "The spec is the useful part, questions are padding" | The questions are the product. The spec is context for them. |
+| "One comment per question is easier to reply to" | One comment. Replies thread under it; multiple comments interleave with the answers. |
+| "The title plus the labels tell me enough" | Read the description. The constraints that break a dispatch are in the prose. |
+| "There's already a prep comment, nothing to do" | Re-read it against the thread. Prep again saying which of its questions are still open. |
+| "I'll note the questions in my reply instead of on the ticket" | The comment is the durable artifact. A reply here is gone by the next session. |

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -65,6 +65,38 @@ Read it from the tracker named by `csw-config get tracker`:
 Read the **whole** description, not the title. Ordering constraints and "replace, do not
 delete" style requirements live in prose and are invisible to structured queries.
 
+### Then read what `csw:prep` left behind
+
+Fetch the ticket's **comments** as well as its description, and look for one prefixed
+`**CSW prep**`:
+
+```bash
+# tracker: github
+gh issue view <number> --comments
+```
+
+For `linear`, list the issue's comments through the Linear MCP tools.
+
+If there is one, it is part of the brief — a first-pass spec, the questions prep thought had
+to be answered before this could run unattended, and anything the ticket asserts that the
+codebase contradicts. Read the replies underneath it too, because that is where the answers
+are:
+
+- **A prep question that has since been answered in the thread is a decision.** Take it and
+  move on. Re-opening it spends the dispatch on a conversation that already happened, and the
+  answer in the thread outranks whatever the description said before it was asked.
+- **A prep question still unanswered is a strong signal this ticket is not ready to run
+  unattended.** Say which questions are still open and take Step 9's draft path,
+  rather than guessing at an answer and building on the guess. A guessed answer is not visible
+  as a guess in the diff — it looks like a decision someone made.
+
+The exception is an `interactive` run, where a human is present to answer: there, prep's open
+questions are the agenda for the Step 1 brainstorm rather than a reason to open a draft PR.
+Nobody to ask is what makes an unanswered question a blocker.
+
+No prep comment is not a problem. Prep is optional, and a ticket without one is dispatched
+exactly as it always was.
+
 ## Step 3: Infer the change type
 
 From the ticket's labels and language, pick one conventional-commit type:
@@ -207,6 +239,8 @@ are actually asking to be merged.
 | "It's 90% done, I'll open a normal PR and flag the gap" | Not merge-ready means draft. Step 9. |
 | "I'll create the worktree with git, it's faster" | Use EnterWorktree. Bypassing it strands state the harness cannot clean up. |
 | "The title tells me enough about the ticket" | Read the description. The ordering constraints are in the prose. |
+| "The description is the brief, I don't need the comments" | A `**CSW prep**` comment is part of the brief, and the answers under it are the decisions. |
+| "Prep's question is unanswered but I can infer the answer" | Then the diff carries a guess that looks like a decision. Step 9, draft. |
 | "No config file, I'll infer the validate command" | Ask. A wrong validate command means a green run that proves nothing. |
 | "They typed a word I don't recognise, I'll get on with the ticket" | An unrecognised modifier is a question, not noise. Name it back and ask. |
 | "It's interactive, so someone is watching — I can merge it" | `interactive` changes planning only. Step 8 is the same hard stop. |

--- a/tests/test-docs.sh
+++ b/tests/test-docs.sh
@@ -12,7 +12,7 @@ if grep -q "Claude Spec Workflow" "$readme"; then
 else
   PASSES=$((PASSES + 1))
 fi
-for phrase in "not yours" "unmaintained" "/csw:work" "/csw:merge" "/csw:cleanup" "/csw:batch"; do
+for phrase in "not yours" "unmaintained" "/csw:prep" "/csw:work" "/csw:merge" "/csw:cleanup" "/csw:batch"; do
   assert_contains "$(cat "$readme")" "$phrase" "README mentions $phrase"
 done
 # A batch's isolation is per ticket in both senses — its own worktree and its own context —

--- a/tests/test-integration.sh
+++ b/tests/test-integration.sh
@@ -37,7 +37,7 @@ for f in "$REPO_ROOT"/bin/*; do
 done
 
 # --- Every skill the README advertises exists. ---
-for s in work merge cleanup batch; do
+for s in prep work merge cleanup batch; do
   if [ -f "$REPO_ROOT/skills/$s/SKILL.md" ]; then
     PASSES=$((PASSES + 1))
   else

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -143,6 +143,48 @@ assert_contains "$work_red_flags" "modifier" \
 assert_contains "$work_red_flags" "interactive" \
   "work: red flags deny that interactive relaxes the hard stop"
 
+# --- prep: specs a ticket, touches nothing ---
+prep="$SKILLS/prep/SKILL.md"
+assert_contains "$(cat "$prep")" "csw-ticket normalize" "prep: normalises the ticket reference"
+assert_contains "$(cat "$prep")" "superpowers:brainstorming" "prep: brainstorms the ticket"
+# Brainstorming's default mode designs the implementation. Prep wants the questions instead —
+# the design belongs to the dispatch that has a worktree to try it in.
+assert_contains "$(cat "$prep")" "surface-the-questions" \
+  "prep: brainstorms for the questions rather than for a design"
+
+# The marker is the whole interface between prep and the dispatch that reads it back. If it
+# drifts, prep still writes a comment and csw:work still finds nothing.
+assert_contains "$(cat "$prep")" '**CSW prep**' "prep: writes the stable marker"
+assert_contains "$(cat "$prep")" "One comment" "prep: leaves exactly one comment, not a thread"
+
+# The three things the comment has to carry. A comment with only a spec is a summary of the
+# ticket, which the ticket already is.
+assert_contains "$(cat "$prep")" "open questions" "prep: the comment carries the open questions"
+assert_contains "$(cat "$prep")" "the codebase contradicts" \
+  "prep: the comment carries what the ticket asserts and the code denies"
+
+# Zero side effects is the property that makes prep free to run before anything is decided,
+# and it is enumerated rather than implied for the same reason batch's dry run enumerates it.
+assert_contains "$(cat "$prep")" \
+  "No worktree, no branch, no pull request, no validation run" \
+  "prep: its no-side-effects property is enumerated, not implied"
+# Todo is self-selecting for the batch loop. Claiming the ticket the way csw:work does would
+# quietly remove every prepped ticket from the column prep exists to improve.
+assert_contains "$(cat "$prep")" "stays in Todo" \
+  "prep: leaves the ticket in Todo so the batch loop still picks it up"
+assert_contains "$(cat "$prep")" "Do not claim it" \
+  "prep: says not to claim the ticket, since reading it is where csw:work claims it"
+
+# Prose has to be able to *name* the things prep must not do, so these match runnable
+# invocations at the start of a line rather than any mention of the word.
+prep_writes=$(grep -nE '^[[:space:]]*(gh pr create|gh pr merge|git worktree|git commit|git push|git checkout|git switch|git branch)' "$prep" || true)
+assert_eq "$prep_writes" "" "prep: contains no runnable command that touches the repo"
+prep_flags=$(fm_field "$prep" 'argument-hint')
+assert_contains "$prep_flags" "ticket" "prep: takes a ticket reference"
+prep_red_flags=$(sed -n '/^## Red flags/,$p' "$prep")
+assert_contains "$prep_red_flags" "worktree" \
+  "prep: red flags catch a prep run that starts doing the work"
+
 # --- merge: never squash, always check CI, always chain into cleanup ---
 merge="$SKILLS/merge/SKILL.md"
 assert_contains "$(cat "$merge")" "gh pr checks" "merge: checks CI"

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -325,6 +325,12 @@ fi
 # goes over on its own.
 assert_contains "$(cat "$batch")" "the ticket reference and nothing else" \
   "batch: dispatches csw:work with no modifier, so no ticket can stop for answers"
+# Prep improves a dispatch but must not become a gate on one: a loop that skipped unprepped
+# tickets would turn an optional command into a required step for every ticket in the column.
+assert_contains "$(cat "$batch")" "Prepped tickets dispatch better" \
+  "batch: names prep as the thing that makes a dispatch land better"
+assert_contains "$(cat "$batch")" "does not skip unprepped" \
+  "batch: prep is a recommendation, never a filter"
 assert_contains "$(cat "$batch")" "A failed selection is never an empty selection" \
   "batch: a filter failure is reported distinctly from an empty batch"
 

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -102,6 +102,29 @@ else
   PASSES=$((PASSES + 1))
 fi
 
+# --- work: reading what csw:prep left behind ---
+#
+# Prep writes its spec and its open questions to a ticket comment. If Step 2 does not go and
+# read that comment, prep is a command that produces nothing anyone consumes.
+work_step2=$(sed -n '/^## Step 2/,/^## Step 3/p' "$work")
+assert_contains "$work_step2" '**CSW prep**' \
+  "work: Step 2 looks for the marker csw:prep writes"
+assert_contains "$work_step2" "comments" \
+  "work: Step 2 reads the ticket's comments, not only its description"
+# A question prep asked and a human answered is a settled decision. Re-opening it burns the
+# dispatch on a conversation that already happened.
+assert_contains "$work_step2" "is a decision" \
+  "work: an answered prep question is treated as settled, not re-litigated"
+# Unanswered questions are the signal prep exists to produce. Guessing past them is exactly
+# the wasted dispatch prep was added to avoid.
+assert_contains "$work_step2" "rather than guessing" \
+  "work: unanswered prep questions are not guessed past"
+assert_contains "$work_step2" "Step 9" \
+  "work: unanswered prep questions route to the draft path"
+work_red_flags=$(sed -n '/^## Red flags/,$p' "$work")
+assert_contains "$work_red_flags" "prep" \
+  "work: red flags catch a dispatch that ignores the prep comment"
+
 # --- work: the interactive modifier, and everything it does not change ---
 
 # The word has to be discoverable from the hint, or the only people who type it are the


### PR DESCRIPTION
Adds `/csw:prep <ticket>` — a spec-only pass that runs in front of a dispatch and touches nothing.

The batch loop only compounds *after* a failure: a ticket blocks, the question lands on the ticket, and the next dispatch starts from a better brief. That costs one wasted dispatch per question discovered. Prep moves the discovery in front of the dispatch, where it costs a comment.

## What changed

**`skills/prep/SKILL.md`** (new) — normalise the reference, read the whole ticket *without claiming it*, run `superpowers:brainstorming` in surface-the-questions mode rather than design-the-implementation mode, and write **one** comment marked `**CSW prep**` carrying a first-pass spec, the open questions that must be answered before it can run unattended, and anything the ticket asserts that the codebase contradicts. Then stop: no worktree, no branch, no PR, no validation run, and the ticket stays in Todo so the batch loop still pulls it.

**`skills/work/SKILL.md`** — Step 2 now fetches the ticket's comments and reads any prior prep comment as part of the brief. A prep question answered in the thread is a decision and is not re-litigated; one still unanswered sends the run to Step 9's draft path rather than a guess, because a guessed answer is not visible as a guess in the diff.

**`skills/batch/SKILL.md`** — one prerequisite paragraph: prepped tickets dispatch better, prep is not required, and the loop does not skip unprepped tickets.

**`README.md`** — prep in the phase diagram, the nightly-loop section, and the commands table.

## Judgment call worth a look

The ticket doesn't cover how prep interacts with `/csw:work ... interactive` (#72, merged since this ticket was written). Sending an interactive run to a draft PR over an unanswered question would be wrong — the human who can answer it is sitting right there — so unanswered prep questions become the agenda for the Step 1 brainstorm on an interactive run, and the draft path applies only to unattended ones. Easy to strip out if you'd rather it stayed literal to the ticket.

## Testing

`bash tests/run-tests.sh` — 10 files, all green. 21 new assertions across `test-skills.sh`, plus prep added to `test-integration.sh`'s skill-existence loop and `/csw:prep` to `test-docs.sh`'s README phrase list. No `bin/**` changes, so no gates fired.

No CHANGELOG or VERSION change: this repo releases in a separate `chore(release)` commit, and `test-docs.sh` fails on any `## [Unreleased]` section.

Closes #73