### PR TITLE
feat: make csw:prep recommend and record rather than ask (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ out*.
 ## The three phases
 
 ```
-/csw:prep ENG-1088          # optional: spec it, ask the questions, touch nothing
+/csw:prep ENG-1088          # optional: spec it, settle what it can, touch nothing
 /csw:work ENG-1088          # dispatch: worktree, autonomous implementation, PR, stop
   ... you review the diff ...
 go for merge                # merge: CI gate, merge commit, chains into cleanup
@@ -20,12 +20,17 @@ go for merge                # merge: CI gate, merge commit, chains into cleanup
 ```
 
 **Prep** is the optional pass in front of the dispatch. It reads the ticket, brainstorms it for
-the questions that would stop an unattended run, notes anything the ticket asserts that the
-codebase contradicts, and writes all of it to **one ticket comment** marked `**CSW prep**`. It
-opens no worktree, no branch and no PR, and leaves the ticket in Todo. Dispatch reads that
-comment back as part of the brief — answers in the thread are decisions, and questions still
-unanswered send the run to a draft PR instead of a guess. Without it the loop only learns after
-a failure, at the cost of one wasted dispatch per question.
+the questions that would stop an unattended run, and then **answers the ones it can defend an
+answer to** — anything with a precedent in the codebase, a convention the repo follows, or a
+cheap reversal becomes a recorded decision with its reasoning rather than a question. The test
+is mechanical: if prep can mark an option "(Recommended)", it has its answer. What survives is
+put to you in one round, and usually that is nothing. All of it — the spec, the decisions, the
+open questions if any, and anything the ticket asserts that the codebase contradicts — lands in
+**one ticket comment** marked `**CSW prep**`. It opens no worktree, no branch and no PR, and
+leaves the ticket in Todo. Dispatch reads that comment back as part of the brief — decisions
+and answers in the thread are settled, and questions still unanswered send the run to a draft
+PR instead of a guess. Without it the loop only learns after a failure, at the cost of one
+wasted dispatch per question.
 
 **Dispatch** reads the ticket, sets it In Progress, opens a worktree, runs the work
 autonomously test-first, validates, and opens a PR. Then it stops. Hold-for-review is a hard

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ put to you **in the run**, in one round — and usually that is nothing.
 
 Prep is interactive by design: you typed it and you are sitting there, so it ends either with
 every blocking question answered or with prep confirming there were none. Either way the ticket
-is dispatchable when it stops. All of it — the spec, the decisions, the open questions if any,
+is dispatchable when it stops. It writes nothing to the repo, so several sessions prep in
+parallel quite happily — **one ticket per session**, since two sessions on one ticket race two
+comments into the same thread. All of it — the spec, the decisions, the open questions if any,
 and anything the ticket asserts that the codebase contradicts — lands in **one ticket comment**
 marked `**CSW prep**`. It opens no worktree, no branch and no PR, and leaves the ticket in Todo.
 Dispatch reads that comment back as part of the brief — decisions and answers in the thread are

--- a/README.md
+++ b/README.md
@@ -24,13 +24,16 @@ the questions that would stop an unattended run, and then **answers the ones it 
 answer to** — anything with a precedent in the codebase, a convention the repo follows, or a
 cheap reversal becomes a recorded decision with its reasoning rather than a question. The test
 is mechanical: if prep can mark an option "(Recommended)", it has its answer. What survives is
-put to you in one round, and usually that is nothing. All of it — the spec, the decisions, the
-open questions if any, and anything the ticket asserts that the codebase contradicts — lands in
-**one ticket comment** marked `**CSW prep**`. It opens no worktree, no branch and no PR, and
-leaves the ticket in Todo. Dispatch reads that comment back as part of the brief — decisions
-and answers in the thread are settled, and questions still unanswered send the run to a draft
-PR instead of a guess. Without it the loop only learns after a failure, at the cost of one
-wasted dispatch per question.
+put to you **in the run**, in one round — and usually that is nothing.
+
+Prep is interactive by design: you typed it and you are sitting there, so it ends either with
+every blocking question answered or with prep confirming there were none. Either way the ticket
+is dispatchable when it stops. All of it — the spec, the decisions, the open questions if any,
+and anything the ticket asserts that the codebase contradicts — lands in **one ticket comment**
+marked `**CSW prep**`. It opens no worktree, no branch and no PR, and leaves the ticket in Todo.
+Dispatch reads that comment back as part of the brief — decisions and answers in the thread are
+settled, and questions still unanswered send the run to a draft PR instead of a guess. Without
+it the loop only learns after a failure, at the cost of one wasted dispatch per question.
 
 **Dispatch** reads the ticket, sets it In Progress, opens a worktree, runs the work
 autonomously test-first, validates, and opens a PR. Then it stops. Hold-for-review is a hard
@@ -129,7 +132,7 @@ A different project is a config file, not a fork. Full reference:
 
 | Command | Phase | Invocation |
 |---|---|---|
-| `/csw:prep <ticket>` | Before dispatch | Optional — spec only, no side effects |
+| `/csw:prep <ticket>` | Before dispatch | Optional — interactive, spec only, no side effects |
 | `/csw:work <ticket>` | Dispatch | Command, or "work ENG-1088" |
 | `/csw:work <ticket> interactive` | Dispatch | Brainstorms first, then the same run |
 | `/csw:merge` | Merge | Usually natural language: "go for merge" |

--- a/skills/prep/SKILL.md
+++ b/skills/prep/SKILL.md
@@ -20,6 +20,18 @@ Prep does not implement anything. It reads, it decides everything it can defend 
 recommendation for, it asks about the little that survives that test, and it writes one
 comment carrying all of it.
 
+**Prep is an interactive command**, and that is the design centre rather than a variant of it.
+The person who can answer typed the invocation and is sitting there for the whole run, so a
+run ends in one of two states, both of which leave the ticket **dispatchable**:
+
+- Every question that would block an autonomous build has an answer, recorded on the ticket in
+  the run that asked it.
+- There were none, and prep says so.
+
+The second is the common one and the one to aim for. A question left in a comment for someone
+to notice tomorrow is not a third state — it is the first state, deferred by a day, and that
+day is exactly what prep exists to remove.
+
 ## Step 0: Read the config
 
 ```bash
@@ -138,7 +150,7 @@ five that did not. A decision that should have been a question is written down i
 with its reasoning, where a human reads it and overturns it. **The comment is the safety
 mechanism, not the asking.**
 
-## Step 5: Ask, once, if anyone is there
+## Step 5: Ask, once, and get the answer in this run
 
 If nothing survived Step 4, this step is a no-op. That is the good outcome, not a sign the
 triage was too aggressive — go straight to Step 6.
@@ -148,16 +160,20 @@ each with the recommended option first where there is one. Take the answers; the
 decisions and are recorded as such in Step 6, in the same comment the questions were asked
 from.
 
-Someone typed `/csw:prep <ticket>` and is sitting right there. Proposing a recommendation to a
-human who can reject it is not the failure this command exists to prevent — leaving them to
-read six questions in a comment, answer them in chat, and have somebody copy the answers back
-by hand is.
+Ask them here, in the run. Someone typed `/csw:prep <ticket>` and is sitting right there:
+proposing a recommendation to a human who can reject it is not the failure this command exists
+to prevent — leaving them to read the questions in a comment, answer them in chat, and have
+somebody copy the answers back by hand is. A question that reaches the comment unanswered has
+cost the dispatch a day, and it was answerable in thirty seconds by the person who was in the
+room the whole time.
 
-**If nobody is there to answer, do not ask and do not guess.** Prep invoked from a subagent,
-or a column of tickets prepped in one pass, has no one in the room; the surviving questions
-stay open in the comment instead, which is the case prep was designed against and its original
-behaviour. Nobody to ask is what makes an unanswered question a blocker rather than a
-conversation.
+**If nobody is there to answer, do not ask and do not guess.** Prep invoked from a subagent, or
+a column of tickets prepped in one pass, has no one in the room; the surviving questions stay
+open in the comment instead and the ticket is not yet dispatchable. This is the degenerate
+case, not the shape prep is built around — say plainly, when you report, that the run ended
+with questions nobody was there to answer, because the fix is a human re-running it rather than
+a dispatch reading it. Nobody to ask is what makes an unanswered question a blocker rather than
+a conversation.
 
 ## Step 6: Write one comment
 
@@ -216,16 +232,19 @@ the guess as the brief, and nothing downstream catches it.
 
 ## Step 7: Stop
 
-Report what you wrote and stop.
+Report what you wrote and stop. Say which of the two end states the run reached: the ticket is
+dispatchable with nothing outstanding, or it is not and here is what is still open and why
+nobody answered it.
 
 **No worktree, no branch, no pull request, no validation run**, no commit, and no change to
 the ticket's state — it **stays in Todo** so the batch loop still picks it up. That is prep's
 whole contract, and it is the only reason it is safe to run against a column of tickets before
 anything about them has been decided.
 
-Do not continue into `csw:work`. Prep ending is the point at which a human reads the comment;
-implementing against it is not prep's job, and neither is starting the work while nobody has
-looked at what prep decided.
+Do not continue into `csw:work`. The human who answered the questions has seen the comment go
+by, not agreed to the work starting; deciding when a dispatchable ticket is dispatched is
+theirs, and prep going on to implement against its own spec removes the one review point
+between the brainstorm and a branch.
 
 ## Red flags
 
@@ -235,6 +254,7 @@ looked at what prep decided.
 | "I'm not fully certain, so I'll ask" | Then every ticket costs its prepper six answers and the two that mattered are buried. Recommend, record the reasoning, and move on. |
 | "There's a recommendation, but this feels important enough to confirm" | Important is not the test. Public contract, production data, cannot be walked back by editing a file — otherwise it is a decision. |
 | "Six questions means I was thorough" | It means triage did not run. A run that asks nothing and records six reasoned decisions is the better run. |
+| "I'll leave it open in the comment for them to read" | They are here now — that is what interactive means. A question deferred to the comment is the same answer, a day later. |
 | "I've read enough to just start it — I'll open the worktree" | Prep has no worktree. If it is ready to run, dispatch it with `csw:work`. |
 | "Set it In Progress so nobody double-prepares it" | Todo is what the batch loop pulls. Claiming it un-batches it. |
 | "The spec is the useful part, the rest is padding" | The decisions and the open questions are the product. The spec is context for them. |

--- a/skills/prep/SKILL.md
+++ b/skills/prep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prep
-description: Spec a ticket before it is dispatched. Brainstorms it for the questions that must be answered before it can run unattended, then leaves a first-pass spec as one ticket comment. No worktree, no branch, no pull request, and the ticket stays where it was.
+description: Spec a ticket before it is dispatched. Brainstorms it, decides everything it can recommend an answer for, asks a present human about the little that survives, and leaves the spec, the decisions and anything still open as one ticket comment. No worktree, no branch, no pull request, and the ticket stays where it was.
 when_to_use: "/csw:prep 1088", "prep ENG-1088", "spec ENG-1088 before tonight's batch", "is this ticket ready to dispatch?"
 argument-hint: "[ticket-ref]"
 ---
@@ -16,8 +16,9 @@ ticket, and the next dispatch starts from a better brief — so one wasted dispa
 of every question discovered. Prep moves that discovery in front of the dispatch, where it
 costs a comment instead of a night.
 
-Prep does not implement anything, and it does not decide anything a human should. It reads,
-it asks, and it writes one comment.
+Prep does not implement anything. It reads, it decides everything it can defend a
+recommendation for, it asks about the little that survives that test, and it writes one
+comment carrying all of it.
 
 ## Step 0: Read the config
 
@@ -63,8 +64,9 @@ pulls, which removes it from the very column prep exists to improve.
 Read the existing comments too, and read them before brainstorming rather than after. A
 question already asked and answered in the thread is a decision, not an open question, and
 re-asking it in the prep comment tells the next dispatch to go and re-litigate it. If a prior
-`**CSW prep**` comment is already there, this run supersedes it: say which questions it left
-unanswered and do not simply repeat the ones that have since been settled.
+`**CSW prep**` comment is already there, this run supersedes it: carry its decisions forward,
+say which of its questions are still open, and do not repeat the ones that have since been
+settled.
 
 ## Step 3: Brainstorm it, in surface-the-questions mode
 
@@ -83,16 +85,81 @@ has since moved is a dispatch that will spend its run discovering that.
 What to come out with:
 
 - **A first-pass spec.** What the change is, in the terms the codebase actually uses.
-- **The open questions** — specifically the ones that must be answered before this can run
+- **The candidate questions** — the ones that must be answered before this can run
   *unattended*. That is the bar. "Which of these two names is nicer" does not stop a dispatch;
-  "does this replace the existing path or sit alongside it" does.
+  "does this replace the existing path or sit alongside it" does. They are *candidates*: Step 4
+  decides which of them prep answers itself and which are worth a human's attention.
 - **Contradictions.** Anything the ticket asserts that the codebase contradicts, quoted from
   both sides so a human can adjudicate it without going and looking.
 
 If the superpowers skills are not installed, say so once and do the same work by hand. The
 skill is a strong recommendation, not a hard dependency.
 
-## Step 4: Write one comment
+## Step 4: Triage — decide what you can defend, keep only what you cannot
+
+Take every candidate from Step 3 and apply one mechanical test:
+
+> **If you can mark an option "(Recommended)", you have your answer.** Do not ask — decide,
+> and record the decision with the reasoning that made it one.
+
+That test is not a judgement call about how important the uncertainty feels. It is something
+prep can apply to itself: if you find yourself writing an option list whose first entry is the
+obvious one, that list is a decision you have not finished making. It comes from measurement —
+prep run over four tickets asked 4-6 questions on every one of them, and **every question that
+carried a recommendation was answered by taking the recommendation**, without exception. Those
+questions carried no information. They were a confirmation step wearing a question's clothing,
+and a human paid for it on every ticket.
+
+A recommendation is what a precedent gives you: something the codebase already does, a
+convention the repo already follows, or a choice that is cheap to reverse because reversing it
+means editing a file.
+
+Two branches survive, and everything else is a decision:
+
+1. **No recommendation can be formed.** Not enough clarity to pick means it is genuinely a
+   question. This is the common legitimate case, and it should still be rare.
+2. **The cost of being wrong is paid outside this repo.** Ask even holding a recommendation,
+   because the criterion here is blast radius rather than confidence: a released config key's
+   name, a public output contract, production data touched or migrated — anything that
+   **cannot be walked back by editing a file**. That is a named class of consequence, not a
+   feeling that something seems important, and it has to stay that narrow. Left vague it
+   reabsorbs everything branch one excluded and prep is back to six questions a ticket.
+
+**Question count is a quality signal, and it runs the opposite way to the obvious reading.** A
+run that asks nothing and records six reasoned decisions is a *better* run than one that asks
+six questions. Zero questions is the expected outcome, and frequently the right one; 0-2 is the
+range. Six on one ticket reads as prep failing to do its job, not as prep being thorough — and
+"surface the questions" pulls naturally towards surfacing all of them, which is exactly the
+failure this step exists to stop.
+
+The asymmetry is why the test is set this way round. A question that should have been a
+decision costs its prepper an answer on every ticket, and buries the one that mattered among
+five that did not. A decision that should have been a question is written down in the comment
+with its reasoning, where a human reads it and overturns it. **The comment is the safety
+mechanism, not the asking.**
+
+## Step 5: Ask, once, if anyone is there
+
+If nothing survived Step 4, this step is a no-op. That is the good outcome, not a sign the
+triage was too aggressive — go straight to Step 6.
+
+Otherwise, put the surviving questions to the human in **one round**, with **AskUserQuestion**,
+each with the recommended option first where there is one. Take the answers; they become
+decisions and are recorded as such in Step 6, in the same comment the questions were asked
+from.
+
+Someone typed `/csw:prep <ticket>` and is sitting right there. Proposing a recommendation to a
+human who can reject it is not the failure this command exists to prevent — leaving them to
+read six questions in a comment, answer them in chat, and have somebody copy the answers back
+by hand is.
+
+**If nobody is there to answer, do not ask and do not guess.** Prep invoked from a subagent,
+or a column of tickets prepped in one pass, has no one in the room; the surviving questions
+stay open in the comment instead, which is the case prep was designed against and its original
+behaviour. Nobody to ask is what makes an unanswered question a blocker rather than a
+conversation.
+
+## Step 6: Write one comment
 
 **One comment**, on the ticket, prefixed with the marker exactly:
 
@@ -112,9 +179,13 @@ The body:
 ## First-pass spec
 <what the change is, in the codebase's own terms>
 
+## Decisions
+1. <the choice, stated as settled> — <the reasoning that made it a decision rather than a
+   question: the precedent it follows, or why it is cheap to reverse>
+2. <a question Step 5 put to a human, and the answer they gave> — decided in this run.
+
 ## Open questions
-1. <a question that would stop an unattended dispatch>
-2. <another>
+_None._
 
 ## What the ticket asserts that the codebase contradicts
 - <claim> — <what is actually there, with the path>
@@ -124,15 +195,26 @@ The marker `**CSW prep**` is load-bearing and must be exact. `csw:work` Step 2 s
 comments for that string; a comment that says "Prep notes" instead is a comment nothing will
 ever read back.
 
-**One comment, not a thread.** Answers arrive as replies underneath it, and a human scanning
-the ticket has to be able to tell prep's questions from prep's own restatements of them. Three
-comments from prep means the answers interleave with the questions and nobody can tell which
-is which.
+**Every decision carries its reasoning.** A decision written down without the precedent behind
+it is indistinguishable from a guess, and a reader who cannot see why it was made cannot
+overturn it — which is the one safety mechanism the triage in Step 4 relies on.
 
-Leave the questions genuinely open. Prep answering its own questions is the failure this
-command exists to prevent — an unattended dispatch will then treat the guess as the brief.
+**An empty open-questions section says so.** Write `_None._` under the heading rather than
+dropping the heading, because "nothing left open" is a dispatchable signal and an absent
+section is not: a dispatch reading this back cannot tell a prep run that settled everything
+from a prep run that never got that far.
 
-## Step 5: Stop
+**One comment, not a thread.** Answers to anything still open arrive as replies underneath it,
+and a human scanning the ticket has to be able to tell prep's questions from prep's own
+restatements of them. Three comments from prep means the answers interleave with the questions
+and nobody can tell which is which — which is also why the answers Step 5 collected belong in
+this comment rather than a second one.
+
+Whatever survived Step 4 and had no human to answer it stays genuinely open. Prep answering
+those questions unattended is the failure this command exists to prevent — the dispatch treats
+the guess as the brief, and nothing downstream catches it.
+
+## Step 7: Stop
 
 Report what you wrote and stop.
 
@@ -141,17 +223,22 @@ the ticket's state — it **stays in Todo** so the batch loop still picks it up.
 whole contract, and it is the only reason it is safe to run against a column of tickets before
 anything about them has been decided.
 
-Do not continue into `csw:work`. Prep ending is the point at which a human reads the questions;
-answering them is not prep's job, and neither is starting the work while nobody has.
+Do not continue into `csw:work`. Prep ending is the point at which a human reads the comment;
+implementing against it is not prep's job, and neither is starting the work while nobody has
+looked at what prep decided.
 
 ## Red flags
 
 | Thought | Reality |
 |---|---|
-| "I know what they meant, I'll answer the question myself" | Then the dispatch inherits your guess as the brief. Leave it open. |
+| "I know what they meant, I'll answer the question myself" | With **nobody watching**, that guess becomes the brief and nothing downstream catches it. Recommending it to a present human who can reject it is a different act; writing it into the comment unattended is not. |
+| "I'm not fully certain, so I'll ask" | Then every ticket costs its prepper six answers and the two that mattered are buried. Recommend, record the reasoning, and move on. |
+| "There's a recommendation, but this feels important enough to confirm" | Important is not the test. Public contract, production data, cannot be walked back by editing a file — otherwise it is a decision. |
+| "Six questions means I was thorough" | It means triage did not run. A run that asks nothing and records six reasoned decisions is the better run. |
 | "I've read enough to just start it — I'll open the worktree" | Prep has no worktree. If it is ready to run, dispatch it with `csw:work`. |
 | "Set it In Progress so nobody double-prepares it" | Todo is what the batch loop pulls. Claiming it un-batches it. |
-| "The spec is the useful part, questions are padding" | The questions are the product. The spec is context for them. |
+| "The spec is the useful part, the rest is padding" | The decisions and the open questions are the product. The spec is context for them. |
+| "Nothing is open, so I'll drop the section" | `_None._` is a signal a dispatch reads. A missing section is silence. |
 | "One comment per question is easier to reply to" | One comment. Replies thread under it; multiple comments interleave with the answers. |
 | "The title plus the labels tell me enough" | Read the description. The constraints that break a dispatch are in the prose. |
 | "There's already a prep comment, nothing to do" | Re-read it against the thread. Prep again saying which of its questions are still open. |

--- a/skills/prep/SKILL.md
+++ b/skills/prep/SKILL.md
@@ -168,12 +168,22 @@ cost the dispatch a day, and it was answerable in thirty seconds by the person w
 room the whole time.
 
 **If nobody is there to answer, do not ask and do not guess.** Prep invoked from a subagent, or
-a column of tickets prepped in one pass, has no one in the room; the surviving questions stay
-open in the comment instead and the ticket is not yet dispatchable. This is the degenerate
-case, not the shape prep is built around — say plainly, when you report, that the run ended
-with questions nobody was there to answer, because the fix is a human re-running it rather than
-a dispatch reading it. Nobody to ask is what makes an unanswered question a blocker rather than
-a conversation.
+a column of tickets prepped by one unattended run, has no one in the room; the surviving
+questions stay open in the comment instead and the ticket is not yet dispatchable. This is the
+degenerate case, not the shape prep is built around — say plainly, when you report, that the
+run ended with questions nobody was there to answer, because the fix is a human re-running it
+rather than a dispatch reading it. Nobody to ask is what makes an unanswered question a blocker
+rather than a conversation.
+
+**Several prep sessions running at once is the interactive path, not that fallback.** Four
+sessions, four tickets, one human moving between them: you are present in every one, so every
+session asks and gets its answer normally. It parallelises safely because prep writes nothing
+to the repo and each session comments on a different ticket. What does collide is two sessions
+given the *same* ticket — both write a `**CSW prep**` comment, neither is in a position to
+supersede the other's the way Step 2 assumes, and the dispatch reads back two briefs for one
+change. **One ticket per session.** Parallelism also sharpens the triage in Step 4 rather than
+relaxing it: six questions apiece across four sessions is twenty-four interruptions to a human
+who is already context-switching between four tickets.
 
 ## Step 6: Write one comment
 

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -77,11 +77,17 @@ gh issue view <number> --comments
 
 For `linear`, list the issue's comments through the Linear MCP tools.
 
-If there is one, it is part of the brief — a first-pass spec, the questions prep thought had
-to be answered before this could run unattended, and anything the ticket asserts that the
+If there is one, it is part of the brief — a first-pass spec, the decisions prep made with the
+reasoning behind each, whatever it could not settle, and anything the ticket asserts that the
 codebase contradicts. Read the replies underneath it too, because that is where the answers
 are:
 
+- **A decision prep recorded is a decision.** It comes with its reasoning so you can see the
+  precedent it followed; build on it. Re-deciding it is the same wasted conversation as
+  re-opening an answered question. Overturning one takes something the reasoning did not
+  account for — say so on the ticket if you find it.
+- **`## Open questions` reading `_None._` means nothing is outstanding.** A missing section is
+  not the same claim: treat it as an older prep comment and read the questions out of the body.
 - **A prep question that has since been answered in the thread is a decision.** Take it and
   move on. Re-opening it spends the dispatch on a conversation that already happened, and the
   answer in the thread outranks whatever the description said before it was asked.

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -401,4 +401,45 @@ assert_contains "$(cat "$batch")" "effective cap and where it came from" \
 assert_contains "$(cat "$batch")" "A filter failure in a dry run is a failure, not an empty plan" \
   "batch: a dry run cannot launder a failed selection into a quiet night"
 
+# --- prep: recommends by default, asks only what a recommendation cannot settle ---
+# Measured over four tickets: prep asked 4-6 questions on each, and every question carrying a
+# recommendation was answered by taking the recommendation. Those questions carried no
+# information — they were a confirmation step billed to a human on every ticket. So the test
+# for asking is mechanical and prep can apply it to itself: can a recommendation be formed?
+assert_contains "$(cat "$prep")" '(Recommended)' \
+  "prep: forming a recommendation at all is the test for not asking"
+assert_contains "$(cat "$prep")" "Question count is a quality signal" \
+  "prep: says explicitly that asking fewer is better, against the natural surface-them-all pull"
+
+# The two branches that survive. Branch two is about blast radius rather than confidence, and
+# has to name a class of consequence — left vague it reabsorbs everything branch one excluded
+# and prep is back to six questions a ticket.
+assert_contains "$(cat "$prep")" "No recommendation can be formed" \
+  "prep: names the first branch that legitimately asks"
+assert_contains "$(cat "$prep")" "cannot be walked back by editing a file" \
+  "prep: bounds the second branch to a class of consequence, not a feeling of importance"
+
+# The answers have to land in the same comment they were asked in. A decision recorded
+# without its reasoning is indistinguishable from a guess, which is the thing prep forbids.
+assert_contains "$(cat "$prep")" "## Decisions" \
+  "prep: the comment carries the decisions, not only what prep could not settle"
+assert_contains "$(cat "$prep")" "the reasoning that made it a decision" \
+  "prep: a recorded decision carries the reasoning a human would need to overturn it"
+# An absent section is not a signal. "Nothing left open" is, and a dispatch reads it back.
+assert_contains "$(cat "$prep")" "_None._" \
+  "prep: an empty open-questions section says so rather than disappearing"
+
+# Recommending to a human who can reject it needs a human. Without one — a subagent, a column
+# of tickets prepped in one pass — the questions that survive triage stay open.
+assert_contains "$(cat "$prep")" "AskUserQuestion" \
+  "prep: puts the surviving questions to the human who is actually sitting there"
+assert_contains "$(cat "$prep")" "nobody is there to answer" \
+  "prep: falls back to leaving questions open when there is no human in the room"
+
+# Both directions have to be answered where an agent looks when it is about to rationalise.
+assert_contains "$prep_red_flags" "nobody watching" \
+  "prep: red flags keep the ban on guessing, bounded to the unattended case"
+assert_contains "$prep_red_flags" "so I'll ask" \
+  "prep: red flags catch the reverse failure, asking rather than recommending"
+
 report

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -429,6 +429,14 @@ assert_contains "$(cat "$prep")" "the reasoning that made it a decision" \
 assert_contains "$(cat "$prep")" "_None._" \
   "prep: an empty open-questions section says so rather than disappearing"
 
+# Prep is run with the person who can answer sitting there — that is the design centre, not a
+# variant of it. Framed the other way round the skill defers every surviving question to a
+# comment someone reads tomorrow, which is the day of latency prep exists to remove.
+assert_contains "$(cat "$prep")" "Prep is an interactive command" \
+  "prep: the run with a human present is the norm, not the exception"
+assert_contains "$(cat "$prep")" "dispatchable" \
+  "prep: names the state a run has to leave the ticket in"
+
 # Recommending to a human who can reject it needs a human. Without one — a subagent, a column
 # of tickets prepped in one pass — the questions that survive triage stay open.
 assert_contains "$(cat "$prep")" "AskUserQuestion" \

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -443,6 +443,11 @@ assert_contains "$(cat "$prep")" "AskUserQuestion" \
   "prep: puts the surviving questions to the human who is actually sitting there"
 assert_contains "$(cat "$prep")" "nobody is there to answer" \
   "prep: falls back to leaving questions open when there is no human in the room"
+# Several prep sessions at once is the interactive path, not the fallback — the human is in
+# every one of them. The only thing that actually collides is two sessions on one ticket,
+# which races two markers into a thread whose supersede rule assumes one writer.
+assert_contains "$(cat "$prep")" "One ticket per session" \
+  "prep: parallel sessions are safe per ticket, and the collision is naming the same ticket twice"
 
 # Both directions have to be answered where an agent looks when it is about to rationalise.
 assert_contains "$prep_red_flags" "nobody watching" \


### PR DESCRIPTION
Prep ended with a list of open questions and stopped. That was designed for prepping a column ahead of an unattended night; it is wrong for the case it is actually invoked in, where a human typed `/csw:prep <ticket>` and is sitting right there. Measured over four tickets, prep asked 4-6 questions on every one — and every question that carried a recommendation was answered by taking the recommendation. Those questions carried no information.

## What changed

**`skills/prep/SKILL.md`**
- **New Step 4, triage.** One mechanical test, applicable by prep to itself: if you can mark an option "(Recommended)", you have your answer — decide it and record the reasoning. Two branches survive to be asked: no recommendation can be formed, or the cost of being wrong is paid outside this repo and cannot be walked back by editing a file (released config key name, public output contract, production data). The second branch is deliberately narrow, and the prose says why it has to stay that way.
- **Question count is a quality signal running the opposite way to the obvious reading** — stated explicitly, because "surface the questions" pulls towards surfacing all of them. Zero is the expected outcome; six on one ticket is prep failing.
- **New Step 5, ask once.** Survivors go to the human in a single `AskUserQuestion` round, recommended option first. Nothing survived is a no-op and the good outcome. **Nobody in the room** — a subagent, a column prepped in one pass — falls back to today's behaviour: leave them open, never guess.
- **The comment gains `## Decisions`**, each with the reasoning that made it a decision, and `## Open questions` reads `_None._` rather than disappearing, since nothing-outstanding is a dispatchable signal and an absent section is not.
- **Red flags rewritten in both directions.** The ban on guessing keeps its boundary rather than going away (guessing unattended ≠ recommending to a present human), and the reverse row lands: "I'm not fully certain, so I'll ask".

**`skills/work/SKILL.md`** — the consumer's description of the comment was left accurate: it now names decisions as part of the brief, says a recorded decision is settled and what it takes to overturn one, and reads `_None._` as the all-clear while treating a missing section as an older prep comment.

**`README.md`** — prep's advertised behaviour is described there, so it follows the change.

**`tests/test-skills.sh`** — 11 new assertions immediately before `report`, pinning the recommendation test, both asking branches, the quality-signal prose, the decisions section and its reasoning, `_None._`, `AskUserQuestion`, the no-human fallback, and both red-flag directions. The existing prep assertions at the marker, `open questions` and `the codebase contradicts` all still hold.

## Validation

`bash tests/run-tests.sh` — all test files pass (156 in `test-skills.sh`). `csw-gates --files` over the committed diff plus the working tree fires nothing; the only gate is `bin/**` and this touches no scripts.

## Worth a human's eye

This is a behavioural skill, so the tests pin phrases, not behaviour — whether the prose actually produces zero-question prep runs only shows up by dogfooding `/csw:prep` on a live ticket. #74 is the worked example: under this rule it should have asked zero and recorded six decisions, or at most one (the config key's name).

Two calls beyond the letter of the ticket, both flagged rather than assumed: the `csw:work` edit (the ticket's Touches list omits it, but its enumeration of the comment's contents goes stale otherwise), and placing the new assertions immediately before the final `report` call as the ticket asks, which puts prep assertions below the batch section rather than beside the other prep ones.

Closes #95