### PR TITLE
test: close the false-positive guard class in test-skills.sh (#69)

### DIFF
--- a/tests/test-assert-guards.sh
+++ b/tests/test-assert-guards.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Tests for assert_guards, the region-scoped assertion in test-helpers.sh.
+#
+# assert_guards exists because a whole-file `assert_contains` does not
+# necessarily guard anything. If the needle also occurs somewhere the guarded
+# behaviour does not live, reverting that behaviour leaves the needle behind and
+# the assertion stays green — a guard that cannot go red. That is #69.
+#
+# The property assert_guards adds is: the needle must be found *inside the
+# region of the file that documents the behaviour*. Revert the behaviour and the
+# region goes with it, the extraction comes back empty, and the assertion fails.
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+
+# Run assert_guards in a subshell and report only whether it passed, so its
+# effect on the counters stays inside the subshell and does not pollute this
+# file's own tally. The subshell prints the FAILURES it ended with; comparing
+# that to ours tells us which way it went.
+guard_result() { # file start end needle label -> "pass" | "fail"
+  local ended_at
+  ended_at=$(
+    assert_guards "$@" 2>/dev/null
+    printf '%s' "$FAILURES"
+  )
+  if [ "$ended_at" = "$FAILURES" ]; then printf 'pass\n'; else printf 'fail\n'; fi
+}
+
+fixture=$(mktemp -d)
+TMPDIRS+=("$fixture")
+doc="$fixture/doc.md"
+cat >"$doc" <<'EOF'
+## Step 3: Remove it
+
+- **The native tool already removed it.** Running the command again fails with
+  `is not a working tree` — that is success, not a problem to report.
+
+- **The manual path was used.** The thing is still there, so remove it first.
+
+The remote branch is already gone if the merge used `--delete-branch`.
+EOF
+
+start='^- \*\*The native tool already removed it\.\*\*'
+end='^- \*\*The manual path was used\.\*\*'
+
+# The needle lives inside the region: the ordinary passing case.
+assert_eq "$(guard_result "$doc" "$start" "$end" 'is not a working tree' l)" "pass" \
+  "assert_guards: passes when the needle is inside the region"
+
+# Absent from the file entirely — no different from assert_contains.
+assert_eq "$(guard_result "$doc" "$start" "$end" 'nowhere in this file' l)" "fail" \
+  "assert_guards: fails when the needle is absent from the file"
+
+# The #69 case in miniature. `already gone` is in the file, but in the unrelated
+# remote-branch sentence, not in the region the guard claims to protect. A
+# whole-file assert_contains passes here; assert_guards must not.
+assert_eq "$(guard_result "$doc" "$start" "$end" 'already gone' l)" "fail" \
+  "assert_guards: fails when the needle is in the file but outside the region"
+
+# The revert. The bullet the guard protects is gone, so the region start no
+# longer matches and the extraction is empty. This is the property that makes
+# the guard bite, checked on every run rather than proved once by hand.
+reverted="$fixture/reverted.md"
+grep -v 'is not a working tree' "$doc" | grep -v '^- \*\*The native tool already removed it' >"$reverted"
+assert_eq "$(guard_result "$reverted" "$start" "$end" 'is not a working tree' l)" "fail" \
+  "assert_guards: fails when the region it scopes to no longer exists"
+
+# A start that matches with no end that does makes sed run the range to EOF, so
+# the "region" silently becomes the rest of the file and the scoping is lost.
+# That is the same failure mode test-skills.sh guards against when it requires a
+# closing `---` before trusting a frontmatter extraction. Fail loudly instead.
+assert_eq "$(guard_result "$doc" "$start" '^## Step 4' 'already gone' l)" "fail" \
+  "assert_guards: fails when the region end never matches rather than running to EOF"
+
+report

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -38,6 +38,63 @@ assert_contains() { # haystack needle label
   esac
 }
 
+# assert_guards <file> <region-start> <region-end> <needle> <label>
+#
+# A *guard* claims to protect a specific documented behaviour, and its whole
+# job is to go red when that behaviour is removed. `assert_contains` against a
+# whole file does not do that on its own: if the needle also occurs somewhere
+# the behaviour does not live, reverting the behaviour leaves the needle behind
+# and the assertion stays green. That is #69 — `already gone` was asserted
+# against all of skills/cleanup/SKILL.md, and the file's unrelated "The remote
+# branch is already gone…" sentence kept it passing with the fix reverted.
+#
+# assert_guards scopes the needle to the region of the file that documents the
+# behaviour. Revert the behaviour and the region goes with it, so the
+# extraction comes back empty and the assertion fails.
+#
+# `<region-start>` and `<region-end>` are sed address regexes, matched against
+# whole lines of <file>. They are deliberately free-form rather than heading
+# names: on skills/cleanup/SKILL.md the unrelated sentence sits *inside* Step
+# 3's own section, so a region at heading granularity still contains it. A
+# region has to be able to name a single bullet.
+#
+# Use this for assertions that guard a behaviour. A presence check — "the
+# README mentions X at all" — has no fix to revert and no region to scope to,
+# so plain assert_contains remains the right tool there.
+assert_guards() {
+  local file=$1 start=$2 end=$3 needle=$4 label=$5 region
+
+  if [ ! -f "$file" ]; then
+    FAILURES=$((FAILURES + 1))
+    printf 'FAIL %s\n  no such file: [%s]\n' "$label" "$file" >&2
+    return
+  fi
+
+  region=$(sed -n "/$start/,/$end/p" "$file")
+
+  # An empty extraction means the region start never matched — which is exactly
+  # what a revert of the guarded behaviour looks like.
+  if [ -z "$region" ]; then
+    FAILURES=$((FAILURES + 1))
+    printf 'FAIL %s\n  region start never matched: [%s] in %s\n' "$label" "$start" "$file" >&2
+    return
+  fi
+
+  # If the start matches but the end never does, sed runs the range to EOF and
+  # the "region" quietly becomes the rest of the file — the scoping is gone and
+  # the assertion is a whole-file check again, without looking like one. Require
+  # the extraction to actually terminate on <region-end>. (test-skills.sh guards
+  # its frontmatter extraction against the same run-to-EOF failure.)
+  if ! printf '%s\n' "$region" | tail -1 | grep -qE "$end"; then
+    FAILURES=$((FAILURES + 1))
+    printf 'FAIL %s\n  region end never matched: [%s] in %s — extraction ran to EOF\n' \
+      "$label" "$end" "$file" >&2
+    return
+  fi
+
+  assert_contains "$region" "$needle" "$label"
+}
+
 assert_status() { # expected-code label -- command...
   local expected=$1 label=$2 actual
   shift 3 # drop expected, label, and the literal --

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -272,7 +272,15 @@ assert_contains "$(cat "$cleanup")" "never require a separate instruction" "clea
 assert_contains "$(cat "$cleanup")" "gh pr view --json state,mergedAt" "cleanup: verifies the PR is merged before removing anything"
 assert_contains "$(cat "$cleanup")" "unknown, not absent" "cleanup: a failed sweep is reported distinctly from an empty one"
 assert_contains "$(cat "$cleanup")" "the command failing for any reason" "cleanup: any gh pr view failure is a stop, not just a non-merged state"
-assert_contains "$(cat "$cleanup")" "already gone" \
+# Scoped to the ExitWorktree bullet itself, not to the whole file and not to Step 3. The
+# needle this replaces was `already gone` against the whole file, which also matched Step 3's
+# unrelated "The remote branch is already gone…" sentence — so the assertion passed with the
+# fix reverted and guarded nothing (#69). Section granularity does not fix it either: that
+# sentence is inside Step 3's own section. The region has to be the bullet.
+assert_guards "$cleanup" \
+  '^- \*\*Step 2 used the native ExitWorktree tool\.\*\*' \
+  '^- \*\*Step 2 fell back to the manual' \
+  'that is "already gone," which is success' \
   "cleanup: Step 3 treats a worktree ExitWorktree already removed as success, not failure"
 # The sweep now reports a merged branch even when it is checked out, which
 # `git branch -d` refuses. Cleanup has to know to land on the base first.

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -80,12 +80,36 @@ if [ "$skill_count" -eq 0 ]; then
   printf 'FAIL no skill directories found under skills/\n' >&2
 fi
 
+# --- assert_contains vs assert_guards, throughout this file ---
+#
+# Every assertion here guards a behaviour some skill documents, and its job is to
+# go red when that behaviour is removed. A whole-file `assert_contains` only does
+# that while its needle occurs *nowhere else in the file*: the moment it also
+# appears somewhere the behaviour does not live, a revert leaves the needle
+# behind and the assertion stays green while guarding nothing. That is #69.
+#
+# So the rule in this file is mechanical rather than stylistic: **if the needle
+# is not unique to the behaviour's own region, the assertion uses
+# `assert_guards`** and names the region it protects. A needle that occurs once
+# already has the property — it vanishes with the region — and stays on
+# `assert_contains`.
+#
+# A deliberate consequence: a region is *not* required to be the only place the
+# needle appears in the file. Every skill restates its load-bearing rules in
+# `## Red flags`, and this file separately asserts those restatements. Requiring
+# the needle to be absent outside its region would fail on that convention
+# working as intended, and would only be the uniqueness rule under another name.
+# Present-inside-the-region is what makes a revert bite; that is the whole
+# contract.
+
 # --- work: the hard stop and the tools it must reach for ---
 work="$SKILLS/work/SKILL.md"
 assert_contains "$(cat "$work")" "csw-ticket normalize" "work: normalises the ticket reference"
 assert_contains "$(cat "$work")" "csw-ticket branch" "work: derives the branch name"
-assert_contains "$(cat "$work")" "csw-gates" "work: runs diff-triggered gates"
-assert_contains "$(cat "$work")" "EnterWorktree" "work: prefers the native worktree tool"
+assert_guards "$work" '^## Step 6: Validate' '^## Step 7: Commit and open the PR' \
+  "csw-gates" "work: runs diff-triggered gates"
+assert_guards "$work" '^## Step 4: Open an isolated workspace' '^## Step 5: Do the work' \
+  "EnterWorktree" "work: prefers the native worktree tool"
 assert_contains "$(cat "$work")" "--draft" "work: knows the draft-PR rule"
 assert_contains "$(cat "$work")" "Hold for review is a hard stop" "work: states the hard stop"
 assert_contains "$(cat "$work")" "No PR means Step 9, not Step 8" "work: Step 7 failures route to Step 9"
@@ -179,18 +203,25 @@ assert_contains "$(cat "$prep")" "csw-ticket normalize" "prep: normalises the ti
 assert_contains "$(cat "$prep")" "superpowers:brainstorming" "prep: brainstorms the ticket"
 # Brainstorming's default mode designs the implementation. Prep wants the questions instead —
 # the design belongs to the dispatch that has a worktree to try it in.
-assert_contains "$(cat "$prep")" "surface-the-questions" \
+assert_guards "$prep" '^## Step 3: Brainstorm it' '^## Step 4: Triage' \
+  "surface-the-questions" \
   "prep: brainstorms for the questions rather than for a design"
 
 # The marker is the whole interface between prep and the dispatch that reads it back. If it
-# drifts, prep still writes a comment and csw:work still finds nothing.
-assert_contains "$(cat "$prep")" '**CSW prep**' "prep: writes the stable marker"
-assert_contains "$(cat "$prep")" "One comment" "prep: leaves exactly one comment, not a thread"
+# drifts, prep still writes a comment and csw:work still finds nothing. Scoped to Step 6,
+# which is the step that writes it — Step 2's mention is prep *reading back* an earlier
+# comment, and would keep this green with the writing side gone.
+assert_guards "$prep" '^## Step 6: Write one comment' '^## Step 7: Stop' \
+  '**CSW prep**' "prep: writes the stable marker"
+assert_guards "$prep" '^## Step 6: Write one comment' '^## Step 7: Stop' \
+  "One comment" "prep: leaves exactly one comment, not a thread"
 
 # The three things the comment has to carry. A comment with only a spec is a summary of the
-# ticket, which the ticket already is.
+# ticket, which the ticket already is. Scoped to Step 6 for the same reason: Step 3 tells prep
+# to *find* contradictions, Step 6 is what puts them in the comment.
 assert_contains "$(cat "$prep")" "open questions" "prep: the comment carries the open questions"
-assert_contains "$(cat "$prep")" "the codebase contradicts" \
+assert_guards "$prep" '^## Step 6: Write one comment' '^## Step 7: Stop' \
+  "the codebase contradicts" \
   "prep: the comment carries what the ticket asserts and the code denies"
 
 # Zero side effects is the property that makes prep free to run before anything is decided,
@@ -217,8 +248,10 @@ assert_contains "$prep_red_flags" "worktree" \
 
 # --- merge: never squash, always check CI, always chain into cleanup ---
 merge="$SKILLS/merge/SKILL.md"
-assert_contains "$(cat "$merge")" "gh pr checks" "merge: checks CI"
-assert_contains "$(cat "$merge")" "gh pr merge" "merge: merges the PR"
+assert_guards "$merge" '^## Step 3: Check CI' '^## Step 4: Merge' \
+  "gh pr checks" "merge: checks CI"
+assert_guards "$merge" '^## Step 4: Merge' '^## Step 5: Chain into cleanup' \
+  "gh pr merge" "merge: merges the PR"
 assert_contains "$(cat "$merge")" "--merge --delete-branch" "merge: merge commit, delete the branch (local and remote)"
 assert_contains "$(cat "$merge")" "csw:cleanup" "merge: chains into cleanup"
 assert_contains "$(cat "$merge")" "gh pr view <number> --json state,mergedAt" \
@@ -234,10 +267,19 @@ assert_contains "$(cat "$merge")" "BLOCKED" "merge: covers mergeStateStatus BLOC
 
 # --- cleanup: sweeps unprompted, asks only about the tracker ---
 cleanup="$SKILLS/cleanup/SKILL.md"
-assert_contains "$(cat "$cleanup")" "csw-sweep" "cleanup: runs the sweep"
-assert_contains "$(cat "$cleanup")" "ExitWorktree" "cleanup: prefers the native worktree exit"
-assert_contains "$(cat "$cleanup")" "git worktree remove" "cleanup: removes the worktree"
-assert_contains "$(cat "$cleanup")" "git worktree prune" "cleanup: prunes stale registrations"
+assert_guards "$cleanup" '^## Step 4: Sweep for everything else' \
+  '^### The branch you are standing on' \
+  "csw-sweep" "cleanup: runs the sweep"
+assert_guards "$cleanup" '^## Step 2: Leave the worktree' '^### When ExitWorktree warns' \
+  "ExitWorktree" "cleanup: prefers the native worktree exit"
+# The removal itself belongs to Step 3's manual bullet: on the ExitWorktree path the tool has
+# already done it, and every other occurrence in this file is prose *about* the command.
+assert_guards "$cleanup" '^- \*\*Step 2 fell back to the manual' \
+  '^If `git branch -d` refuses' \
+  "git worktree remove" "cleanup: removes the worktree"
+assert_guards "$cleanup" '^## Step 3: Remove this worktree and branch' \
+  '^## Step 4: Sweep for everything else' \
+  "git worktree prune" "cleanup: prunes stale registrations"
 # The pull must bind both paths, not just the manual fallback — an ExitWorktree cleanup
 # that skips it leaves the local base branch behind the merge it just landed.
 assert_contains "$(cat "$cleanup")" "on either path" "cleanup: pulls the base branch on both paths"
@@ -252,7 +294,8 @@ assert_eq "$bare_pull" "" \
   "cleanup: every runnable git pull prunes, so the sweep's [gone] arm reads fresh state"
 assert_contains "$(cat "$cleanup")" "only a prune" \
   "cleanup: says why the prune is load-bearing, not cosmetic"
-assert_contains "$(cat "$cleanup")" "sibling" "cleanup: checks for sibling PRs in other repos"
+assert_guards "$cleanup" '^## Step 5: The tracker, last' '^## Red flags' \
+  "sibling" "cleanup: checks for sibling PRs in other repos"
 # The sibling search must be scoped to this repo's owner. Unscoped, `gh search prs` runs
 # across all of GitHub, and with `tracker: github` the ticket is a bare number — searching
 # for 81 returned 30 strangers' PRs and not one sibling.
@@ -296,13 +339,21 @@ assert_contains "$(cat "$cleanup")" "git branch --show-current      # must be" \
 # ExitWorktree's "will discard N commits" warning fires on essentially every cleanup,
 # because cleanup always runs right after a forge-side merge. It must be proven false
 # against the remote, never waved through and never stalled on.
-assert_contains "$(cat "$cleanup")" "git merge-base --is-ancestor" \
+assert_guards "$cleanup" '^### When ExitWorktree warns it will discard commits' \
+  '^### Land on the base branch' \
+  "git merge-base --is-ancestor" \
   "cleanup: proves the discard warning false against the remote instead of trusting it"
 assert_contains "$(cat "$cleanup")" "Non-zero means the warning is real" \
   "cleanup: a non-zero merge-base check stops the cleanup"
-assert_contains "$(cat "$cleanup")" "discard_changes: true" \
+assert_guards "$cleanup" '^### When ExitWorktree warns it will discard commits' \
+  '^### Land on the base branch' \
+  "discard_changes: true" \
   "cleanup: names the flag that must never be passed unverified"
-assert_contains "$(cat "$cleanup")" "display only" \
+# Narrower than the subsection: this is the "not the branch rename" bullet specifically, which
+# is the claim being guarded. The Red-flags row restating it is asserted separately below.
+assert_guards "$cleanup" '^- \*\*Not the branch rename\.\*\*' \
+  '^- \*\*Not a reason to skip Step 1\.\*\*' \
+  "display only" \
   "cleanup: says the stale branch name in the warning is cosmetic, not a reason to dismiss the count"
 # Red flags are where an agent looks when it is about to rationalise. The verification
 # rule has to appear there too, not only in the step prose.
@@ -322,8 +373,11 @@ assert_contains "$(cat "$cleanup")" "cannot be suppressed" \
 # --- batch: never auto-invoked, always explains its skips ---
 batch="$SKILLS/batch/SKILL.md"
 assert_eq "$(fm_field "$batch" 'disable-model-invocation')" "true" "batch: never model-invoked"
-assert_contains "$(cat "$batch")" "csw-batch-filter" "batch: delegates selection"
-assert_contains "$(cat "$batch")" "csw:work" "batch: dispatches through the work skill"
+assert_guards "$batch" '^## Step 2: Select' '^## Step 3: If this is a dry run' \
+  "csw-batch-filter" "batch: delegates selection"
+assert_guards "$batch" '^## Step 5: Dispatch each to a fresh subagent' \
+  '^## Step 6: When a ticket blocks or fails' \
+  "csw:work" "batch: dispatches through the work skill"
 assert_contains "$(cat "$batch")" "--draft" "batch: blocked work becomes a draft PR"
 assert_contains "$(cat "$batch")" "Morning summary" "batch: reports a morning summary"
 # Case-insensitive: the prerequisite reads naturally as a sentence-initial "Backfill", and a
@@ -355,7 +409,9 @@ assert_contains "$(cat "$batch")" "A failed selection is never an empty selectio
 # inherited ticket one's plan, its diff and its dead ends. Worktrees were isolated; the mind
 # driving them was not. Each ticket now gets a subagent, which is the programmatic equivalent
 # of clearing context between dispatches.
-assert_contains "$(cat "$batch")" "fresh subagent" \
+assert_guards "$batch" '^## Step 5: Dispatch each to a fresh subagent' \
+  '^## Step 6: When a ticket blocks or fails' \
+  "fresh subagent" \
   "batch: each ticket is dispatched to a subagent of its own"
 assert_contains "$(cat "$batch")" "Never run \`csw:work\` in this session" \
   "batch: the controlling session never does a ticket's work itself"
@@ -392,7 +448,8 @@ assert_contains "$batch_red_flags" "subagent" \
   "batch: red flags catch a dispatch run in the controlling session"
 assert_contains "$(cat "$batch")" "can only lower tonight's cap, never raise it" \
   "batch: the cap override is documented as lower-only"
-assert_contains "$(cat "$batch")" "csw-config get batch.maxTickets" \
+assert_guards "$batch" '^## Step 2: Select' '^## Step 3: If this is a dry run' \
+  "csw-config get batch.maxTickets" \
   "batch: reads the configured cap before evaluating an override"
 
 # --- batch: the filter's three-key output, and the dry run that reads it ---
@@ -400,7 +457,8 @@ assert_contains "$(cat "$batch")" "csw-config get batch.maxTickets" \
 # The skill has to name belowCap, because it is the group whose whole reason for existing
 # is that a reader can tell it apart from skipped. Prose that only mentions two groups
 # teaches the old shape back.
-assert_contains "$(cat "$batch")" "belowCap" "batch: names the filter's belowCap group"
+assert_guards "$batch" '^## Step 2: Select' '^## Step 3: If this is a dry run' \
+  "belowCap" "batch: names the filter's belowCap group"
 assert_contains "$(cat "$batch")" "never blames the cap" \
   "batch: says skipped carries no cap reason"
 
@@ -458,7 +516,8 @@ assert_contains "$(cat "$prep")" "Question count is a quality signal" \
 # and prep is back to six questions a ticket.
 assert_contains "$(cat "$prep")" "No recommendation can be formed" \
   "prep: names the first branch that legitimately asks"
-assert_contains "$(cat "$prep")" "cannot be walked back by editing a file" \
+assert_guards "$prep" '^## Step 4: Triage' '^## Step 5: Ask, once' \
+  "cannot be walked back by editing a file" \
   "prep: bounds the second branch to a class of consequence, not a feeling of importance"
 
 # The answers have to land in the same comment they were asked in. A decision recorded
@@ -468,7 +527,8 @@ assert_contains "$(cat "$prep")" "## Decisions" \
 assert_contains "$(cat "$prep")" "the reasoning that made it a decision" \
   "prep: a recorded decision carries the reasoning a human would need to overturn it"
 # An absent section is not a signal. "Nothing left open" is, and a dispatch reads it back.
-assert_contains "$(cat "$prep")" "_None._" \
+assert_guards "$prep" '^## Step 6: Write one comment' '^## Step 7: Stop' \
+  "_None._" \
   "prep: an empty open-questions section says so rather than disappearing"
 
 # Prep is run with the person who can answer sitting there — that is the design centre, not a
@@ -476,7 +536,10 @@ assert_contains "$(cat "$prep")" "_None._" \
 # comment someone reads tomorrow, which is the day of latency prep exists to remove.
 assert_contains "$(cat "$prep")" "Prep is an interactive command" \
   "prep: the run with a human present is the norm, not the exception"
-assert_contains "$(cat "$prep")" "dispatchable" \
+# The two-end-states contract is stated in the preamble, which is also where the assertion
+# above it looks. Elsewhere in the file "dispatchable" is prose leaning on that contract.
+assert_guards "$prep" '^\*\*Prep is an interactive command\*\*' '^## Step 0' \
+  "dispatchable" \
   "prep: names the state a run has to leave the ticket in"
 
 # Recommending to a human who can reject it needs a human. Without one — a subagent, a column


### PR DESCRIPTION
The `already gone` assertion guarding `skills/cleanup/SKILL.md` Step 3 passed with the fix
reverted, because the file's unrelated "The remote branch is already gone…" sentence kept the
needle present. It guarded nothing. This closes that, and the class it belongs to.

## What changed

**`assert_guards` in `tests/test-helpers.sh`** — scopes a needle to the region of a file that
documents the behaviour being guarded. Delete the behaviour and the region goes with it, so the
extraction comes back empty and the assertion fails. It also fails loudly when the region *end*
never matches, because sed would otherwise run the range to EOF and silently turn the check back
into a whole-file one.

**26 assertions migrated** across all five skills — every whole-file assertion in
`tests/test-skills.sh` whose needle also occurred outside the behaviour it guards. After this,
**no whole-file assertion in that file carries a non-unique needle.**

**`tests/test-assert-guards.sh`** — five tests for the helper, including the #69 case in
miniature and the run-to-EOF case.

## Proof that the guards bite

Green is not evidence for a guard. Each guard's region was deleted from a scratch copy and the
guard re-run:

- **27 / 27 guards fail** when the region they claim to protect is deleted.
- **18 of those** are guards where the *old* whole-file needle **survived** the same revert —
  live false positives, not defensive changes: `EnterWorktree`, `**CSW prep**`, `One comment`,
  `the codebase contradicts`, `csw-sweep`, `git worktree remove`, `sibling`,
  `git merge-base --is-ancestor`, `discard_changes: true`, `display only`, `csw-batch-filter`,
  `csw:work`, `fresh subagent`, `belowCap`, `cannot be walked back by editing a file`,
  `_None._`, `dispatchable`, and cleanup's `ExitWorktree`.
- The remaining 9 were already confined to their region, so the old assertion bit too. Migrating
  them is correctness maintenance, not a fix — called out rather than counted as one.

The original #69 guard was separately revert-tested against `19de21e^`: the old `already gone`
assertion **passes** on the reverted file, the new one **fails** with `region start never matched`.

## Decisions this implements

Both recorded on the ticket before the work started:

- **`absent outside the region` is not part of the contract.** Present-inside-region is what
  makes a revert bite; absent-outside adds none and is the uniqueness rule under another name,
  which the earlier answers comment forbade. It also collides with the Red-flags convention —
  14 of the 26 needles occur inside `## Red flags` by design, and the suite separately asserts
  those restatements. This overturns the first answers comment's "and absent outside it" on
  grounds it had not accounted for.
- **Scope is the non-unique set.** A guard with a unique needle already bites — the needle
  vanishes with its region — so the non-unique set is exactly where the #69 failure mode lives.
  `tests/test-docs.sh` (presence checks) and the command-output assertions in
  `test-csw-sweep.sh` / `test-csw-batch-filter.sh` are out of scope.

## Worth a look on review

- **The region boundaries.** Each is a pair of sed address regexes, and they are the load-bearing
  part. Two are deliberately narrower than a heading: cleanup's `display only` scopes to the
  `- **Not the branch rename.**` bullet, and the #69 guard scopes to the
  `- **Step 2 used the native ExitWorktree tool.**` bullet — section granularity does not fix
  either, since the colliding text sits inside the same section.
- **Region regexes are repeated where guards share a region** rather than hoisted into
  variables. A renamed heading then fails loudly at every site instead of silently at the ones
  someone forgot, which seemed the better trade for a file whose whole subject is silent guards.
- **Not done:** a lint that would fail the suite if a *future* whole-file assertion arrived with
  a non-unique needle. It needs the continuation-aware parser used to audit this change, and is a
  reasonable follow-up rather than part of #69.

Closes #69
