### PR TITLE
fix: derive the Step 6 gate file list in csw-gates, not the shell (#70)

### DIFF
--- a/bin/csw-gates
+++ b/bin/csw-gates
@@ -9,9 +9,92 @@ die() { printf 'csw-gates: %s\n' "$1" >&2; exit "$2"; }
 usage() {
   cat <<'EOF'
 Usage:
-  csw-gates <base-ref>   Diff <base-ref>...HEAD and print the gates it triggers
-  csw-gates --files      Read a newline-separated file list from stdin instead
+  csw-gates <base-ref>              Diff <base-ref>...HEAD and print the gates it triggers
+  csw-gates --worktree <base-ref>   ...unioned with the working tree, for an uncommitted change
+  csw-gates --files                 Read a newline-separated file list from stdin instead
 EOF
+}
+
+files=''
+
+# Append one path to the file list, rejecting anything the line-based matching
+# below cannot represent.
+add_path() { # path
+  case $1 in
+    '') return 0 ;;
+    *$'\n'*)
+      # Same failure class, same exit code and phrasing, as csw-sweep's check
+      # against a path its output format cannot carry. Silently skipping a
+      # configured gate is a wrong answer, not a safe default.
+      die "path contains a newline, which the line-based gate matching cannot represent: $1" 2
+      ;;
+  esac
+  files="${files}$1
+"
+}
+
+# Every path that will exist once the current work is committed: the committed
+# diff against <base-ref>, unioned with the working tree.
+#
+# Both halves are read NUL-delimited. That is the whole point of this mode: git's
+# default output C-style-quotes any path containing a space or a non-ASCII byte,
+# and writes a rename as `old -> new` on one line, so any line-based parse can be
+# broken by a path's own content — and a path that arrives mangled matches no
+# glob, which shows up as a gate that silently did not run.
+TMPDIR_TO_CLEAN=''
+cleanup_tmpdir() { [ -z "$TMPDIR_TO_CLEAN" ] || rm -rf "$TMPDIR_TO_CLEAN"; }
+
+collect_worktree() { # base-ref
+  local base=$1 dir rec st path _rename_source
+  dir=$(mktemp -d) || die "cannot create a temporary directory" 2
+  # Via a global rather than an expanded-now trap string: the die()s below exit
+  # from inside this function, and a path with a quote in it would break the
+  # quoting of a `trap "rm -rf '$dir'"`.
+  TMPDIR_TO_CLEAN=$dir
+  trap cleanup_tmpdir EXIT
+
+  # `--diff-filter=d` drops deletions: this is a list of paths that survive the
+  # commit, and a path that is going away has nothing left to validate.
+  git diff -z --name-only --diff-filter=d "$base...HEAD" >"$dir/committed" 2>/dev/null \
+    || die "cannot diff $base...HEAD" 2
+  # `-uall` expands an untracked directory into the files inside it. Without it,
+  # a brand-new `backend/migrations/0002.sql` arrives as the single path
+  # `backend/` and no `**/migrations/**` gate ever fires — the most common miss,
+  # and one that needs no unusual filename at all.
+  git status --porcelain -z -uall >"$dir/worktree" 2>/dev/null \
+    || die "cannot read the working tree status" 2
+
+  while IFS= read -r -d '' path; do
+    add_path "$path"
+  done <"$dir/committed"
+
+  # Porcelain v1 under -z is `XY <path>\0` per entry, where X is the index status
+  # and Y the working-tree status.
+  while IFS= read -r -d '' rec; do
+    [ -n "$rec" ] || continue
+    st=${rec:0:2}
+    path=${rec:3}
+    case $st in
+      R*|C*|?R|?C)
+        # A rename or a copy is two records, and under -z they run new path
+        # first, old path second — the reverse of the default format's
+        # `old -> new`. Consume the second and drop it: it is the path that
+        # stops existing. A copy uses the identical wire format, so it takes
+        # this same branch rather than one of its own.
+        IFS= read -r -d '' _rename_source || true
+        ;;
+    esac
+    # A `D` in either column means the path is gone by the time Step 7 commits,
+    # whether it was deleted from the index or from the working tree.
+    case $st in
+      *D*) continue ;;
+    esac
+    add_path "$path"
+  done <"$dir/worktree"
+
+  cleanup_tmpdir
+  TMPDIR_TO_CLEAN=''
+  trap - EXIT
 }
 
 # Convert a config glob to an anchored POSIX extended regex.
@@ -58,6 +141,10 @@ case "${1:-}" in
     ;;
   --files)
     files=$(cat)
+    ;;
+  --worktree)
+    [ -n "${2:-}" ] || die "--worktree needs a base ref" 2
+    collect_worktree "$2"
     ;;
   *)
     # Silence git's own error output (a ~50-line usage dump on a bad ref, or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,8 +96,15 @@ deployment.
 Preview the gates a branch triggers:
 
 ```bash
-csw-gates main
+csw-gates main              # committed history only
+csw-gates --worktree main   # ...plus whatever is still uncommitted
 ```
+
+`--worktree` is the one to reach for before a commit exists — it unions the committed diff with
+the working tree and reports the gates for the tree as it will look once you commit it, so a
+migration you have written but not yet added still fires its gate. Uncommitted deletions drop
+out, renames and copies count as their destination, and a path containing a literal newline is
+a hard error rather than a gate that quietly does not run.
 
 `gates` must be a JSON array of objects, each with both `when` and `run`; anything else
 (a non-array, a non-object entry, or an entry missing either key) is a configuration error,

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -155,25 +155,30 @@ a series of confirmations.
 ## Step 6: Validate
 
 ```bash
-csw-config get validate     # run whatever this prints; empty means the repo declared none
-{ git diff --name-only "<baseBranch>...HEAD"; git status --porcelain | cut -c4- | sed 's/.* -> //'; } \
-  | csw-gates --files        # run every line it prints
+csw-config get validate            # run whatever this prints; empty means the repo declared none
+csw-gates --worktree "<baseBranch>"  # run every line it prints
 ```
 
-Step 7, not this one, is where `git add -A && git commit` happens. A `csw-gates <baseBranch>`
-diff against the merge base only sees committed history, so anything written in Step 5 but not
-yet committed — a new migration file, say — is invisible to it and no gate fires on it. Feed
-`csw-gates --files` both sources: the committed diff against `<baseBranch>`, and
-`git status --porcelain` for whatever is still sitting uncommitted in the working tree. Either
-source alone misses real changes; together they cover the whole tree as it will look after
-Step 7 commits it.
+Step 7, not this one, is where `git add -A && git commit` happens. A plain
+`csw-gates <baseBranch>` diffs against the merge base and so only sees committed history:
+anything written in Step 5 but not yet committed — a new migration file, say — is invisible to
+it and no gate fires on it. `--worktree` is the mode for exactly this moment. It unions the
+committed diff against `<baseBranch>` with the working tree and reports the gates for the tree
+as it will look after Step 7 commits it.
 
-`git status --porcelain`'s short format is two status letters, a space, then the path —
-`cut -c4-` strips exactly that three-character prefix. A rename reads `R  old -> new`, which
-after `cut -c4-` is the single string `old -> new`; that would not match any real gate glob by
-coincidence, so `sed 's/.* -> //'` reduces it to just `new` — the path that will actually exist
-once this commits. The old path is deliberately dropped rather than also emitted: it is about
-to stop existing, so there is nothing left for a gate to validate against it.
+Do not hand-roll that union out of `git status` in the shell. `--worktree` reads git
+NUL-delimited precisely because the line-based forms cannot be parsed safely: git C-style-quotes
+any path containing a space or a non-ASCII byte, writes a rename on one line as `old -> new`,
+and collapses a brand-new untracked directory to the directory alone — so a new
+`backend/migrations/0002.sql` arrives as `backend/` and `**/migrations/**` never fires. Each of
+those reaches a matcher mangled or not at all, which shows up as a gate that silently did not
+run: the exact failure this step exists to prevent.
+
+What comes out is the set of paths that will exist once this commits. Deletions contribute
+nothing, since a path that is going away has nothing left to validate. A rename or a copy
+contributes its destination only, for the same reason. A path containing a literal newline
+cannot be represented in line-based matching at all, so it is a hard error rather than a
+skipped gate.
 
 Gates are gates. If one fails, fix it and re-run. If you cannot fix it, you are in Step 9.
 

--- a/tests/test-csw-gates.sh
+++ b/tests/test-csw-gates.sh
@@ -192,4 +192,160 @@ badref_stderr=$(cd "$badref" && "$BIN/csw-gates" totally-bogus-ref-xyz 2>&1 >/de
 assert_eq "$badref_stderr" 'csw-gates: cannot diff totally-bogus-ref-xyz...HEAD' \
   "bad base ref stderr is only the csw-gates message, no git usage block"
 
+# --- --worktree mode -------------------------------------------------------
+#
+# The set of paths that will exist once the current work is committed: the
+# committed diff against <base-ref>, unioned with the working tree. Every case
+# below is one the old `git status --porcelain | cut -c4- | sed 's/.* -> //'`
+# pipeline in csw:work Step 6 got wrong, silently dropping a gate.
+
+MIGRATE="just backend migrate-checksums"
+
+# A repo on main with the two gates these cases exercise. Callers seed and
+# commit whatever main should already contain, then branch themselves.
+wt_repo() {
+  local d
+  d=$(make_repo)
+  write_config "$d" <<'JSON'
+{
+  "gates": [
+    { "when": "**/migrations/**", "run": "just backend migrate-checksums" },
+    { "when": "*.sql",            "run": "just sql-lint" }
+  ]
+}
+JSON
+  printf '%s\n' "$d"
+}
+
+# Commit a five-line .sql at <repo>/<path> on the current branch.
+wt_seed_sql() { # repo path
+  mkdir -p "$(dirname "$1/$2")"
+  printf 'select 1;\nselect 2;\nselect 3;\nselect 4;\nselect 5;\n' >"$1/$2"
+  git -C "$1" add -A
+  git -C "$1" commit -qm "seed $2"
+}
+
+# 1. An untracked file inside a brand-new untracked directory. The common miss:
+#    without `-uall` git collapses this to `?? newdir/` and `**/migrations/**`
+#    never fires. No unusual filename required.
+r=$(wt_repo)
+git -C "$r" checkout -q -b feat/probe
+mkdir -p "$r/backend/migrations"
+printf 'select 1;\n' >"$r/backend/migrations/0002.sql"
+assert_eq "$(in_dir "$r" "$BIN/csw-gates" --worktree main)" "$MIGRATE" \
+  "--worktree: untracked file in a brand-new untracked directory fires its gate"
+
+# 2. An untracked path containing a space. git C-style-quotes any path with a
+#    space or a non-ASCII byte, and the quotes match no glob.
+r=$(wt_repo)
+git -C "$r" checkout -q -b feat/probe
+printf 'select 1;\n' >"$r/plain space.sql"
+assert_eq "$(in_dir "$r" "$BIN/csw-gates" --worktree main)" "just sql-lint" \
+  "--worktree: an untracked path containing a space fires its gate"
+
+# 3. A staged rename whose destination contains a literal ' -> ' — the repro on
+#    the ticket. Under -z the record order is new path first, old path second.
+r=$(wt_repo)
+git -C "$r" checkout -q -b feat/probe
+wt_seed_sql "$r" m/a.sql
+mkdir -p "$r/backend/migrations"
+git -C "$r" mv m/a.sql "backend/migrations/weird -> evil.sql"
+assert_eq "$(in_dir "$r" "$BIN/csw-gates" --worktree main)" "$MIGRATE" \
+  "--worktree: staged rename to a path containing ' -> ' fires its gate"
+
+# 4. The same rename left unstaged. Nothing has run `git add` at Step 6, so this
+#    is the shape that actually shows up: ' D old' plus '?? new', no R record.
+r=$(wt_repo)
+git -C "$r" checkout -q -b feat/probe
+wt_seed_sql "$r" m/a.sql
+mkdir -p "$r/backend/migrations"
+mv "$r/m/a.sql" "$r/backend/migrations/weird -> evil.sql"
+assert_eq "$(in_dir "$r" "$BIN/csw-gates" --worktree main)" "$MIGRATE" \
+  "--worktree: unstaged rename to a path containing ' -> ' fires its gate"
+
+# 5. A staged copy whose destination contains ' -> '. Under -z a copy is the
+#    same two-record shape as a rename, so it must take the same branch.
+r=$(wt_repo)
+wt_seed_sql "$r" m/a.sql
+git -C "$r" config status.renames copies
+git -C "$r" checkout -q -b feat/probe
+mkdir -p "$r/backend/migrations"
+cp "$r/m/a.sql" "$r/backend/migrations/weird -> evil.sql"
+printf 'select 6;\n' >>"$r/m/a.sql"   # -C only finds copies of files the same change touches
+git -C "$r" add -A
+assert_eq "$(in_dir "$r" "$BIN/csw-gates" --worktree main)" "$MIGRATE" \
+  "--worktree: staged copy to a path containing ' -> ' fires its gate"
+
+# 6. A deleted path contributes nothing: it will not exist once this commits,
+#    so there is nothing left for a gate to validate against it.
+r=$(wt_repo)
+wt_seed_sql "$r" backend/migrations/0001.sql
+git -C "$r" checkout -q -b feat/probe
+git -C "$r" rm -q backend/migrations/0001.sql
+assert_eq "$(in_dir "$r" "$BIN/csw-gates" --worktree main)" "" \
+  "--worktree: a deleted path does not fire its gate"
+
+# ...including a deletion that is only committed on the branch, which the
+# committed half must drop too.
+r=$(wt_repo)
+wt_seed_sql "$r" backend/migrations/0001.sql
+git -C "$r" checkout -q -b feat/probe
+git -C "$r" rm -q backend/migrations/0001.sql
+git -C "$r" commit -qm "drop migration"
+assert_eq "$(in_dir "$r" "$BIN/csw-gates" --worktree main)" "" \
+  "--worktree: a path deleted in a commit on the branch does not fire its gate"
+
+# 7. A literal newline in a path cannot be represented in the line-based
+#    matching csw-gates does, and silently skipping a gate is the failure this
+#    program exists to prevent. Fail loudly, exit 2.
+r=$(wt_repo)
+git -C "$r" checkout -q -b feat/probe
+printf 'select 1;\n' >"$r/$(printf 'we\nird').sql"
+assert_status 2 "--worktree: a path containing a newline exits 2" -- \
+  sh -c "cd '$r' && '$BIN/csw-gates' --worktree main"
+newline_stderr=$(in_dir "$r" "$BIN/csw-gates" --worktree main 2>&1 >/dev/null)
+assert_contains "$newline_stderr" \
+  'csw-gates: path contains a newline, which the line-based gate matching cannot represent:' \
+  "--worktree: the newline failure names itself"
+
+# The committed half is still there: a change committed on the branch and then
+# left alone fires its gate with a clean working tree.
+r=$(wt_repo)
+git -C "$r" checkout -q -b feat/probe
+wt_seed_sql "$r" backend/migrations/0003.sql
+assert_eq "$(in_dir "$r" "$BIN/csw-gates" --worktree main)" "$MIGRATE" \
+  "--worktree: a change committed on the branch fires its gate"
+
+# Both halves at once, deduped down to the single command they share.
+r=$(wt_repo)
+git -C "$r" checkout -q -b feat/probe
+wt_seed_sql "$r" backend/migrations/0003.sql
+printf 'select 1;\n' >"$r/backend/migrations/0004.sql"
+assert_eq "$(in_dir "$r" "$BIN/csw-gates" --worktree main)" "$MIGRATE" \
+  "--worktree: committed and uncommitted halves are unioned"
+
+# A clean tree with nothing on the branch fires nothing, and still exits 0.
+r=$(wt_repo)
+git -C "$r" checkout -q -b feat/probe
+assert_eq "$(in_dir "$r" "$BIN/csw-gates" --worktree main)" "" \
+  "--worktree: a clean tree with no branch commits produces no output"
+assert_status 0 "--worktree: a clean tree still exits 0" -- \
+  sh -c "cd '$r' && '$BIN/csw-gates' --worktree main"
+
+# A bad base ref fails the same way it does in diff mode, and a missing base ref
+# is a usage error rather than a diff against the empty string.
+r=$(wt_repo)
+assert_status 2 "--worktree: a bad base ref exits 2" -- \
+  sh -c "cd '$r' && '$BIN/csw-gates' --worktree totally-bogus-ref-xyz"
+wt_badref_stderr=$(in_dir "$r" "$BIN/csw-gates" --worktree totally-bogus-ref-xyz 2>&1 >/dev/null)
+assert_eq "$wt_badref_stderr" 'csw-gates: cannot diff totally-bogus-ref-xyz...HEAD' \
+  "--worktree: a bad base ref reports only the csw-gates message"
+assert_status 2 "--worktree without a base ref exits 2" -- \
+  sh -c "cd '$r' && '$BIN/csw-gates' --worktree"
+
+# --files keeps its stdin contract exactly as it was: it is the escape hatch and
+# the test seam, not something --worktree replaced.
+assert_eq "$(printf 'backend/migrations/0002.sql\n' | in_dir "$r" "$BIN/csw-gates" --files)" \
+  "$MIGRATE" "--files still reads a newline-separated list from stdin"
+
 report

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -89,10 +89,17 @@ assert_contains "$(cat "$work")" "EnterWorktree" "work: prefers the native workt
 assert_contains "$(cat "$work")" "--draft" "work: knows the draft-PR rule"
 assert_contains "$(cat "$work")" "Hold for review is a hard stop" "work: states the hard stop"
 assert_contains "$(cat "$work")" "No PR means Step 9, not Step 8" "work: Step 7 failures route to Step 9"
-assert_contains "$(cat "$work")" "csw-gates --files" \
-  "work: Step 6 gates the working tree via --files, not a bare baseBranch diff"
-assert_contains "$(cat "$work")" "git status --porcelain" \
-  "work: Step 6 feeds uncommitted changes into the gate check, not just the committed diff"
+assert_contains "$(cat "$work")" 'csw-gates --worktree "<baseBranch>"' \
+  "work: Step 6 gates the working tree, not a bare baseBranch diff"
+# The old Step 6 hand-rolled the union out of `git status --porcelain | cut | sed`, which git's
+# own quoting, rename format, and untracked-directory collapsing all broke. Deriving the list
+# in the shell is the bug; --worktree exists so the skill does not have to.
+if grep -q 'git status --porcelain' "$work"; then
+  FAILURES=$((FAILURES + 1))
+  printf 'FAIL work: Step 6 must not hand-roll the file list out of git status\n' >&2
+else
+  PASSES=$((PASSES + 1))
+fi
 assert_contains "$(cat "$work")" "returning control to the" \
   "work: Step 8's hard stop acknowledges being dispatched from csw:batch"
 if grep -q "gh pr merge" "$work"; then


### PR DESCRIPTION
Closes #70

## The problem

csw:work Step 6 hand-rolled the union of the committed diff and the working tree in the shell:

```bash
{ git diff --name-only "<baseBranch>...HEAD"; git status --porcelain | cut -c4- | sed 's/.* -> //'; } | csw-gates --files
```

There are **three independent** ways that drops a gate silently, not the one the ticket describes:

```
$ git status --porcelain
R  m/a.sql -> "m/weird -> evil.sql"     # greedy sed + C-style quoting
?? backend/                             # untracked dir collapses
?? "plain space.sql"                    # quoting alone

$ git status --porcelain | cut -c4- | sed 's/.* -> //'
evil.sql"
backend/
"plain space.sql"
```

Not one of those reaches a gate glob. `backend/` is the common miss and needs no unusual
filename at all — it is exactly the "a new migration file, say" case the working-tree half of
Step 6 was written to cover.

## The change

`bin/csw-gates` gains **`--worktree <base-ref>`**, which derives the list itself rather than
being handed one:

- `git status --porcelain -z -uall` — `-z` turns off C-style quoting and delimits with NUL, so
  no path is split on its own content; `-uall` expands untracked directories to their files.
- Under `-z` a rename or copy is two records, **new path first, old second** — the reverse of
  the default `old -> new`. A naive port of the old logic would have kept the doomed path and
  dropped the surviving one.
- Copies take the same branch as renames: identical wire format.
- Deletions contribute nothing, in both halves (`--diff-filter=d` on the committed side).
- A path containing a literal newline cannot be represented in the line-based matching at
  `bin/csw-gates:127`, so it is a `die()` with exit **2** — same failure class, code, and
  phrasing as the existing check in `bin/csw-sweep`. Silently skipping a configured gate is a
  wrong answer, not a safe default.

`--files` is untouched. It stays the escape hatch and the test seam; `--worktree` is a second
entry point, not a replacement.

`skills/work/SKILL.md` Step 6 becomes `csw-gates --worktree "<baseBranch>"`, and the prose that
explained the `cut`/`sed` mechanics is replaced with why the shell must not do this at all.

## Rejected

`git diff --name-only` with a status filter, as the ticket suggests: `git diff` never lists
untracked files, so it would re-open the very bug the working-tree half exists to close.

## Tests

11 new cases in `tests/test-csw-gates.sh` against `--worktree`, each a way the old pipeline
failed: untracked file in a brand-new directory, untracked path with a space, staged rename to
a `' -> '` destination, the same rename unstaged (` D old` + `?? new`, the shape that actually
occurs at Step 6 since nothing is staged yet), staged copy to a `' -> '` destination, deletion
staged and deletion committed, newline path exiting 2, the committed half alone, both halves
unioned, and a clean tree. `tests/test-skills.sh` now asserts Step 6 uses `--worktree` and
**fails** if `git status --porcelain` reappears in the skill.

Full suite green; the `bin/**` shellcheck gate passes, dogfooded through `--worktree` itself.

## Worth a human eye

- The `D`-in-either-column rule for what survives the commit, and the `R`/`C` record-consuming
  branch — verified against git 2.43 output, but they are the parts a different git version
  could in principle move.
- Step 6's new prose: it is the load-bearing instruction, and it now tells the operator *not*
  to reconstruct this in the shell.