### PR TITLE
feat: trackerCommand config key — an escape hatch from tracker MCP (#74)

### DIFF
--- a/bin/csw-config
+++ b/bin/csw-config
@@ -9,6 +9,7 @@ set -euo pipefail
 DEFAULTS='{
   "ticketPrefix": "",
   "tracker": "none",
+  "trackerCommand": "",
   "baseBranch": "main",
   "defaultType": "feat",
   "validate": "",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,7 @@ csw-config path          # which file it read, if any
 |---|---|---|
 | `ticketPrefix` | `""` | Prefix added to a bare number, so `/csw:work 1088` becomes `TRA-1088`. Leave empty and bare numbers are rejected as ambiguous. |
 | `tracker` | `"none"` | `linear` (via MCP), `github` (via `gh`), or `none` (paste the ticket text). |
+| `trackerCommand` | `""` | `/csw:batch` **only**: a command printing the candidate array on stdout, instead of reading the tracker. Must be read-only. Does not replace `tracker`. See below. |
 | `baseBranch` | `"main"` | What PRs target, what "merged" is measured against, and where cleanup returns to. |
 | `defaultType` | `"feat"` | Conventional-commit type used when the ticket gives no signal. |
 | `validate` | `""` | The one command that must pass before a PR opens. Empty means the repo declared none, and CSW will say so rather than guess. |
@@ -60,6 +61,60 @@ Set `ticketPrefix` alongside `tracker: github` and it still applies, so `68` bec
 Every other tracker keeps the strict rule: with no `ticketPrefix`, a bare number does not
 identify anything and is rejected with exit 2. That is deliberate — silently guessing which
 project a number belongs to is worse than refusing.
+
+## `trackerCommand`
+
+An escape hatch for people who would rather shell out to a CLI, or to their own GraphQL query,
+than have an agent talk to the tracker. Empty — the default — and nothing changes: `tracker`
+decides how tickets are read.
+
+Non-empty and `/csw:batch` Step 1 runs it as `bash -c "<string>"` from the repo root, with no
+arguments and no injected environment, exactly as `validate` and `gates[].run` are run. Its
+stdout is used **as-is** as the candidate array. That is the point: one call returning the
+array the filter consumes, rather than several tracker calls plus reshaping across twenty
+tickets in context, which is where the errors come from.
+
+```json
+"tracker": "linear",
+"trackerCommand": "linear-todo --json"
+```
+
+The expected stdout is a JSON array of ticket objects:
+
+```json
+[
+  {
+    "id": "ENG-1075",
+    "state": "Todo",
+    "priority": 2,
+    "labels": ["migration"],
+    "blockedBy": [],
+    "relatedTo": ["ENG-1080", "ENG-1081"]
+  }
+]
+```
+
+Only `id` is required — a non-empty string, unique across the array. `state`, `priority`,
+`labels`, `blockedBy`, and `relatedTo` may each be absent or `null`, with the types above when
+present. What is load-bearing in practice is `state`: it must read exactly `"Todo"` or the
+ticket is dropped as "not in Todo", so a command that omits the field selects nothing at all.
+
+Four things to know before setting it:
+
+- **It is `/csw:batch` only.** `/csw:work` and `/csw:prep` read a single ticket, and they keep
+  reading it through `tracker`. The name suggests otherwise; the scope is batch selection.
+- **`tracker` still has to be correct.** `trackerCommand` replaces the fetch, not the tracker.
+  Priority ordering (below) is keyed off `tracker`, so shelling out to a Linear query and
+  setting `tracker: none` because MCP is no longer in play gets the wrong sort order silently.
+- **A non-zero exit is a failed selection**, reported with the command's stderr verbatim, with
+  nothing dispatched. Printing *nothing at all* is also a failure — a command with nothing to
+  report must print `[]`, which is an empty selection. A failed selection is never an empty one.
+- **It must be read-only.** `/csw:batch --dry-run` reaches Step 1 before it decides to stop, so
+  a dry run does run this command. A dry run's "no side effects" promise covers what CSW does,
+  not what a configured command chooses to do.
+
+The output is not validated before use: it goes straight into `csw-batch-filter`, which exits
+non-zero naming the offending field if the shape is wrong.
 
 ## Gates
 

--- a/examples/csw.json
+++ b/examples/csw.json
@@ -1,6 +1,7 @@
 {
   "ticketPrefix": "TRA",
   "tracker": "linear",
+  "trackerCommand": "",
   "baseBranch": "main",
   "defaultType": "feat",
   "validate": "just validate",

--- a/skills/batch/SKILL.md
+++ b/skills/batch/SKILL.md
@@ -39,8 +39,8 @@ would be a new manual step in front of every ticket in the column.
 
 ## Step 1: Pull the candidates
 
-Read every Todo ticket from the tracker named by `csw-config get tracker` and shape it into
-the filter's input:
+Either way, this step ends with `candidates_json` holding a JSON array in the shape Step 2
+pipes into `csw-batch-filter`:
 
 ```json
 [
@@ -54,6 +54,47 @@ the filter's input:
   }
 ]
 ```
+
+Which way depends on one key:
+
+```bash
+csw-config get trackerCommand
+```
+
+**Empty — read the tracker.** Read every Todo ticket from the tracker named by
+`csw-config get tracker` and shape it into the array above yourself. This is the default, and
+it is what `tracker: linear` does through MCP.
+
+**Non-empty — run it, and its stdout _is the filter's input_.** Do not reshape it, do not
+re-read the tracker, do not merge anything into it. Skipping the in-context reshaping across a
+whole column of tickets is the entire reason the key exists — reshaping the output anyway keeps
+the failure mode it was added to remove:
+
+```bash
+candidates_json=$(bash -c "$(csw-config get trackerCommand)")
+```
+
+- **`bash -c "<string>"` from the repo root, no arguments and no injected environment** — the
+  same way `validate` and `gates[].run` are already run.
+- **Capture stdout and check the exit status before piping.** `bash -c "$cmd" |
+  csw-batch-filter` would report the *filter's* status, not the command's, so a failing command
+  that printed a partial array reads as a selection rather than a failure. A non-zero exit is a
+  **failed selection**: quote its stderr verbatim, say plainly that selection failed and no
+  tickets were dispatched, and stop — exactly as Step 2 does for the filter itself. Do not
+  continue to Step 3.
+- **Step 1 does not pre-check the shape.** `csw-batch-filter` already validates it and exits 2
+  naming the offending field, and Step 2's existing arm turns that into a failed selection.
+  A second shape check here only drifts from the one that matters. Pass the stdout through
+  unread and let the filter speak.
+- **A command that prints nothing has failed, not found nothing.** Empty stdout hits the
+  filter's `no input on stdin` and exits 2, which is a failed selection. A command with nothing
+  to report must print `[]`.
+- **`tracker` still has to be right.** `trackerCommand` replaces only the fetch;
+  `csw-batch-filter` keeps reading `tracker` to rank by priority, so someone shelling out to a
+  Linear GraphQL query still sets `tracker: linear` or gets the wrong order silently.
+- **It must be read-only.** A dry run reaches Step 1 before it reaches Step 3, so it runs this
+  command too — skipping it would leave a dry run with no plan to report. Step 3's "no side
+  effects" promise covers CSW's own actions, not what an arbitrary configured command does.
 
 ## Step 2: Select
 
@@ -274,6 +315,8 @@ Then stop. Merging the night's PRs is a morning decision, made by a human lookin
 | "I'll merge the PRs that clearly passed" | The morning review is the gate. Do not pre-empt it. |
 | "The skip reasons are noise in the summary" | They are the tuning data for the next batch. Report all of them. |
 | "csw-batch-filter printed nothing, must mean no tickets were eligible" | Check the exit code first. Non-zero means selection failed — report the failure, don't dispatch nothing and call it a quiet night. |
+| "trackerCommand printed nothing, must be a quiet night" | Check its exit code, then remember empty output is a *failed* selection — only `[]` is an empty one. |
+| "trackerCommand's output is nearly right, I'll tidy it up" | Then you are doing the in-context reshaping the key exists to avoid. Pass it through; the filter names what's wrong. |
 | "They said cap it at 6 tonight, I'll pass that through" | The override can only lower the cap. `batch.maxTickets` is the ceiling; ignore anything at or above it, and say so. |
 | "Over the cap is skipped, same table" | Different questions. `skipped` is why a ticket must not run; `belowCap` is what a bigger cap would have picked up. Merged, neither is answerable. |
 | "A dry run may as well make the worktrees, they're cheap" | A dry run has no side effects at all. No branches, no worktrees, no ticket state changes — that is the only reason it is safe to run before anything is decided. |

--- a/tests/test-csw-config.sh
+++ b/tests/test-csw-config.sh
@@ -8,6 +8,12 @@ assert_eq "$(cd "$repo" && "$BIN/csw-config" get worktreeDir)" ".worktrees" "def
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get baseBranch)" "main" "default baseBranch"
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get defaultType)" "feat" "default defaultType"
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get ticketPrefix)" "" "default ticketPrefix is empty"
+# Empty means "ask the tracker named by `tracker`", which is the behaviour every existing
+# config already has. A non-empty default would silently shell out on someone else's repo.
+# The exit-status assertion is the load-bearing half: an absent key exits 2 and its command
+# substitution is also the empty string, so assert_eq alone would pass without the default.
+assert_eq "$(cd "$repo" && "$BIN/csw-config" get trackerCommand)" "" "default trackerCommand is empty"
+assert_status 0 "trackerCommand is a known key, not an absent one" -- in_dir "$repo" "$BIN/csw-config" get trackerCommand
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get branchPattern)" "<type>/<ticket>-<slug>" "default branchPattern"
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get gates)" "[]" "default gates is an empty array"
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get batch.maxTickets)" "3" "default batch.maxTickets"
@@ -19,6 +25,7 @@ write_config "$repo" <<'JSON'
 {
   "ticketPrefix": "TRA",
   "tracker": "linear",
+  "trackerCommand": "linear-cli todo --json",
   "validate": "just validate",
   "worktreeDir": ".claude/worktrees",
   "batch": { "maxTickets": 4 }
@@ -26,6 +33,10 @@ write_config "$repo" <<'JSON'
 JSON
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get ticketPrefix)" "TRA" "override ticketPrefix"
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get validate)" "just validate" "override validate"
+# trackerCommand replaces only the fetch, so a repo setting it keeps `tracker` too — the
+# filter's own priority ranking still reads `tracker`.
+assert_eq "$(cd "$repo" && "$BIN/csw-config" get trackerCommand)" "linear-cli todo --json" "override trackerCommand"
+assert_eq "$(cd "$repo" && "$BIN/csw-config" get tracker)" "linear" "trackerCommand does not displace tracker"
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get worktreeDir)" ".claude/worktrees" "override worktreeDir"
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get baseBranch)" "main" "untouched key keeps its default"
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get batch.maxTickets)" "4" "nested override"

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -408,6 +408,33 @@ assert_contains "$(cat "$batch")" "effective cap and where it came from" \
 assert_contains "$(cat "$batch")" "A filter failure in a dry run is a failure, not an empty plan" \
   "batch: a dry run cannot launder a failed selection into a quiet night"
 
+# --- batch: trackerCommand, the escape hatch from tracker MCP ---
+#
+# Step 1 is where the candidates come from, so it is the only step that changes: a non-empty
+# trackerCommand replaces the fetch, and its stdout becomes the same variable Step 2 already
+# pipes into the filter. Asserted on Step 1's own slice so a stray mention elsewhere in the
+# skill cannot pass for the branch actually being written.
+batch_step1=$(sed -n '/^## Step 1/,/^## Step 2/p' "$batch")
+assert_contains "$batch_step1" "csw-config get trackerCommand" \
+  "batch: Step 1 reads trackerCommand rather than assuming the tracker"
+assert_contains "$batch_step1" "bash -c" \
+  "batch: says how the command string is executed, matching validate and gates[].run"
+assert_contains "$batch_step1" "read-only" \
+  "batch: trackerCommand runs in a dry run too, so it must not have side effects"
+# The whole point of the key is skipping in-context reshaping across ~20 tickets, which is
+# where an agent introduces errors. Prose that merely runs the command and then reshapes its
+# output has kept the failure mode it was added to remove.
+assert_contains "$batch_step1" "is the filter's input" \
+  "batch: the command's stdout is used as-is, not reshaped in context"
+# `cmd | csw-batch-filter` reports the filter's status, not the command's, so a failing
+# command that printed a partial array would read as a selection rather than a failure.
+assert_contains "$batch_step1" "exit status before piping" \
+  "batch: a non-zero trackerCommand is caught rather than masked by the pipe"
+assert_contains "$batch_step1" "does not pre-check the shape" \
+  "batch: shape validation stays in csw-batch-filter, which already names the bad field"
+assert_contains "$batch_red_flags" "trackerCommand" \
+  "batch: a red flag catches empty trackerCommand output read as a quiet night"
+
 # --- prep: recommends by default, asks only what a recommendation cannot settle ---
 # Measured over four tickets: prep asked 4-6 questions on each, and every question carrying a
 # recommendation was answered by taking the recommendation. Those questions carried no


### PR DESCRIPTION
Adds a top-level `trackerCommand` config key, default `""`. Non-empty, `/csw:batch` Step 1 runs
it as `bash -c` from the repo root and uses its stdout **as-is** as the candidate array, instead
of reading the tracker and reshaping the result in context. Empty leaves every existing config
behaving exactly as it does today.

The motivation is the batch phase specifically: one call returning exactly the array
`csw-batch-filter` consumes, versus several MCP calls plus in-context reshaping across a whole
Todo column — and the reshaping is where an agent introduces errors. There is no official Linear
CLI, and taking a dependency on a community one is not something this plugin should do; letting
someone point at their own CLI or GraphQL query gets the benefit without the dependency.

Six files, all of them prose or config — no new executable logic:

- `bin/csw-config` — `"trackerCommand": ""` in `DEFAULTS`, no validation arm (it reads like `validate`).
- `skills/batch/SKILL.md` — Step 1 branches on the key; two red-flag rows.
- `docs/configuration.md` — Keys row plus a section giving the array shape, which fields are load-bearing, and the four caveats.
- `examples/csw.json` — the key, empty, since `docs/configuration.md` calls that file the complete version.
- `tests/test-csw-config.sh`, `tests/test-skills.sh` — the default, an override alongside `tracker`, and prose assertions scoped to Step 1's own slice.

Decisions worth a reviewer's attention, all carried from the prep comment on the ticket:

- **`tracker` is not replaced.** `csw-batch-filter`'s `rank()` still reads it, so someone shelling
  out to a Linear query and setting `tracker: none` would silently get the wrong priority order.
  The docs row says so in as many words.
- **Capture stdout, check the exit status, then pipe.** `bash -c "$cmd" | csw-batch-filter` reports
  the filter's status, not the command's — a failing command printing a partial array would read
  as a selection rather than a failure.
- **The skill does not pre-check the shape.** The filter already exits 2 naming the offending
  field; a second check in prose only drifts from it. Consequence: empty output is a *failed*
  selection (`no input on stdin`), and `[]` is the empty one.
- **A dry run still runs the command**, so `trackerCommand` is documented as required to be
  read-only.
- **Batch-only**, despite the name — `/csw:work` and `/csw:prep` keep reading single tickets
  through `tracker`. Not renamed on the branch's own authority; the docs carry the scope.

`bash tests/run-tests.sh` is green (166 in `test-skills.sh`, 35 in `test-docs.sh`), and the
`bin/**` shellcheck gate passes. The docs row is not optional: `tests/test-docs.sh` derives its
assertions from `csw-config json`'s own keys, so the suite fails the moment the default lands
without it.

Worth a human eye: whether Step 1's new branch reads clearly enough that an agent follows the
capture-then-check ordering rather than reaching for the obvious pipe — that is prose, and prose
greps can only confirm the sentences are present.

Closes #74