### PR TITLE
feat: add adrDir, so a dispatch can record a decision that outlives its ticket (#75)

### DIFF
--- a/.claude/csw.json
+++ b/.claude/csw.json
@@ -5,6 +5,7 @@
   "validate": "bash tests/run-tests.sh",
   "worktreeDir": ".claude/worktrees",
   "branchPattern": "<type>/<ticket>-<slug>",
+  "adrDir": "docs/adr",
   "gates": [
     {
       "when": "bin/**",

--- a/bin/csw-config
+++ b/bin/csw-config
@@ -15,6 +15,7 @@ DEFAULTS='{
   "validate": "",
   "worktreeDir": ".worktrees",
   "branchPattern": "<type>/<ticket>-<slug>",
+  "adrDir": "",
   "gates": [],
   "batch": { "maxTickets": 3, "singleWriterLabels": ["migration"] }
 }'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ csw-config path          # which file it read, if any
 | `validate` | `""` | The one command that must pass before a PR opens. Empty means the repo declared none, and CSW will say so rather than guess. |
 | `worktreeDir` | `".worktrees"` | Where fallback worktrees go. Must be gitignored. Ignored when a native worktree tool is available. |
 | `branchPattern` | `"<type>/<ticket>-<slug>"` | Branch name template. Tokens: `<type>`, `<ticket>` (lowercased), `<slug>` (from the title, max 40 chars). |
+| `adrDir` | `""` | Where this repo keeps its architecture decision records, e.g. `docs/adr`. Non-empty and `/csw:work` asks, once, whether the run produced a decision that outlives its ticket. Empty and it never asks. See below. |
 | `gates` | `[]` | Extra validation triggered by which files changed. See below. |
 | `batch.maxTickets` | `3` | Cap on a single `/csw:batch` run. |
 | `batch.singleWriterLabels` | `["migration"]` | Labels admitting at most one ticket per batch. |
@@ -115,6 +116,46 @@ Four things to know before setting it:
 
 The output is not validated before use: it goes straight into `csw-batch-filter`, which exits
 non-zero naming the offending field if the shape is wrong.
+
+## `adrDir`
+
+Build specs are disposable and get swept. Architecture decision records are the artifact that
+persists — and nothing else in CSW ever asks whether a piece of work produced one. A rejected
+approach, a constraint discovered the hard way, a rule the next person will otherwise re-break:
+all of it lands in a PR description that nobody reads again.
+
+Empty — the default — and none of this happens. A repo that keeps no ADRs is never asked the
+question.
+
+Non-empty, and it names the directory:
+
+```json
+"adrDir": "docs/adr"
+```
+
+`/csw:work` then asks itself, once, at its hard stop: did this run produce a decision that
+outlives the ticket? Where the answer is yes it writes the ADR into that directory and pushes
+it onto the pull request as its own commit, announced in the report and the PR body as
+*proposed*. Where the answer is no — which is most of the time, and the expected answer — it
+says nothing and stops as it always did.
+
+- **Most tickets produce nothing durable.** An ADR per feature devalues the practice; the
+  discipline is in the rarity. The prompt is a question, not a deliverable.
+- **The directory supplies the convention.** CSW reads what is already there for the local
+  format and to derive the next `NNNN`. An empty or absent directory falls back to
+  `NNNN-kebab-title.md` with `Date:`, `Status:`, and `Tracking:` naming the tickets, then a
+  `## Context` section. An unset convention is not a reason to skip the question.
+- **Review is the filter, not the prompt.** Both a solo `/csw:work` and a `/csw:batch` subagent
+  write the ADR. A drafted file is concrete and cheap to reject — one revert, since it is
+  always its own commit — where a "candidate" line in a summary is vague and evaporates. No ADR
+  reaches the base branch without the same human review as every other line of the PR.
+- **Two dispatches in one night can claim the same number.** Each branches from the base and
+  neither can see the other's unmerged ADR. Number from the directory at write time and let
+  review renumber the second one; there is no sequencing machinery, and none is wanted.
+
+Where an ADR is warranted, cite it from the README of the code it governs and not only from the
+ADR directory — it wants to be reachable from where the mistake would be made. That is advice,
+not a gate.
 
 ## Gates
 

--- a/examples/csw.json
+++ b/examples/csw.json
@@ -7,6 +7,7 @@
   "validate": "just validate",
   "worktreeDir": ".claude/worktrees",
   "branchPattern": "<type>/<ticket>-<slug>",
+  "adrDir": "docs/adr",
   "gates": [
     {
       "when": "**/migrations/**",

--- a/skills/batch/SKILL.md
+++ b/skills/batch/SKILL.md
@@ -247,6 +247,13 @@ Each subagent returns one structured result and nothing else — no transcript, 
 | `pr` | The pull request URL, or none if it never got that far |
 | `summary` | One line on what changed |
 | `blocker` | For `draft` and `failed`: the question asked, or what stopped it |
+| `adr` | The ADR the dispatch proposed — its path and its title — or none, which is the usual answer |
+
+`adr` is in the contract because it cannot reach the morning any other way. `csw:work` Step 8
+writes the ADR itself when the repo sets `adrDir` — a subagent behaves exactly as a solo run
+does, and nothing about the batch is asked to hold back — but Step 7 below assembles the summary
+from these rows and Step 2's groups and nothing else. An ADR that is not in the row is an ADR
+that merges unnoticed, which is the single way writing them unattended goes wrong.
 
 That row is all the controller keeps. It is what Step 7 assembles the morning summary from,
 which is why the summary is built out of results rather than reconstructed from a transcript.
@@ -294,8 +301,16 @@ reconstructed by hand across the tracker or read back out of a transcript:
 | PRs open | Ticket, PR URL, one line on what changed — the `pr` rows |
 | Blocked with questions | Ticket, the question asked, the draft PR — the `draft` rows |
 | Failed | Ticket and what came back — the `failed` rows, if any |
+| ADRs proposed | Ticket, the ADR's path and title — the `adr` rows, if any. Proposed, not decided |
 | Below the cap | Every `belowCap` id from Step 2, in order — tonight's queue, not tonight's rejects |
 | Skipped and why | Every `skipped` entry from Step 2, verbatim reason |
+
+**ADRs proposed gets its own section, not a note tacked onto a PR row.** An architectural
+decision that merges because nobody noticed it in a summary line is the failure this reporting
+exists to prevent, and a section is what survives a skim of the morning. Most nights it is
+empty, and an empty section says the useful thing too. Each one is a single commit on its PR,
+so rejecting it is a revert — say that, so the morning reads them as proposals rather than as
+decisions already taken.
 
 If Step 2 failed outright, this table is not the report. Say plainly that selection failed,
 quote the filter's message, and that nothing was evaluated or dispatched — never fold a
@@ -326,3 +341,5 @@ Then stop. Merging the night's PRs is a morning decision, made by a human lookin
 | "Give the subagent an isolated worktree so it starts clean" | `csw:work` Step 4 makes the worktree, on the branch derived from the ticket. Pre-isolating it strands the work on a name nothing downstream can find. |
 | "The subagent stalled, I'll pick up where it left off" | One failure is one row in the summary. Record it and dispatch the next ticket. |
 | "I'll paste its transcript into the summary" | The summary is assembled from returned rows. A transcript in the summary is the problem the subagents exist to remove. |
+| "The ADR is a detail, it fits in the PR row" | It gets its own section. An ADR nobody noticed is the one way writing them unattended goes wrong. |
+| "Nobody was watching, so the subagent should not have written an ADR" | It should. Both paths write; review is the filter, and the ADR is its own commit so rejecting it is one revert. |

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -210,10 +210,67 @@ Step 8 needs a real PR URL in hand. No PR means Step 9, not Step 8.
 
 ## Step 8: Stop
 
+### Before the stop: did this produce a decision that outlives the ticket?
+
+```bash
+csw-config get adrDir
+```
+
+**Empty — the default — and none of the rest of this subsection runs.** A repo that keeps no
+architecture decision records is never asked the question, and nothing about this dispatch
+changes.
+
+**Non-empty, and it names the directory this repo keeps its ADRs in.** Ask once: did this run
+produce a decision that outlives its ticket — an approach rejected for a reason, a constraint
+discovered the hard way, a rule the next person will otherwise re-break? The PR description is
+where that knowledge goes to die; an ADR is where it survives.
+
+**Most tickets produce nothing durable, and that is the expected answer.** An ADR per feature
+devalues the practice; the discipline is in the rarity. This is a question, not a deliverable —
+asking it is not the same as answering it yes.
+
+When the answer is genuinely yes, write it and push it onto the PR Step 7 just opened:
+
+1. **Read what is already in that directory** for the local convention and for the next number.
+   Where it is empty or absent, the fallback is `<adrDir>/NNNN-kebab-title.md` starting at
+   `0001`, carrying `Date:`, `Status:`, and `Tracking:` naming the tickets, then a `## Context`
+   section explaining the actual failure, the decision, and its consequences. An unset
+   convention is not a reason to skip the question.
+2. **Commit it on its own**, never folded into the implementation commit:
+   ```bash
+   git add "<adrDir>/NNNN-<title>.md"
+   git commit -m "docs: record ADR NNNN — <title>"
+   ```
+   Rejecting an ADR in review is then one revert, rather than surgery on a diff someone wants
+   to keep. That is what makes writing it unattended safe.
+3. **Re-run the gates for that path, not the whole `validate`:**
+   ```bash
+   printf '%s\n' "<adrDir>/NNNN-<title>.md" | csw-gates --files
+   ```
+   Gates are file-triggered, so a repo with a docs gate still gets it. The full suite is a
+   different matter — no code changed between the two commits, so re-running it doubles every
+   ADR's cost and proves nothing.
+4. **Push to the same branch.** The PR is already open; this is a second commit onto it.
+5. **Say so where a human is already looking** — in the report below and in the PR body, naming
+   the ADR and saying plainly that it is **proposed and revertible**. An ADR that merges
+   unnoticed is the one way this goes wrong.
+
+Two dispatches in one night can both claim the same `NNNN`: each branched from the base, and
+neither can see the other's unmerged ADR. **Number from the directory at write time and let
+review renumber the loser.** A collision is not your error and needs no sequencing machinery.
+
+Where an ADR is warranted, it is worth citing from the README of the code it governs rather
+than only from the ADR directory — reachable from where the mistake would be made. That is
+advice, not a gate: an ADR written without touching a README has failed nothing.
+
+A `csw:batch` dispatch does all of this identically. There is nothing here that differs between
+a solo run and an unattended one, and nothing to check in order to tell them apart.
+
 **Hold for review is a hard stop, not a checkpoint to talk past.** Report:
 
 - The PR URL
 - What changed, in a few lines a reviewer can hold in their head
+- Any ADR this run proposed — its path and its title, and that it is proposed, not decided
 - What is worth testing on hardware — the parts CI cannot cover
 
 Then stop. Do not merge. Do not run `csw:merge`. Do not continue because the invoking
@@ -256,3 +313,7 @@ are actually asking to be merged.
 | "They typed a word I don't recognise, I'll get on with the ticket" | An unrecognised modifier is a question, not noise. Name it back and ask. |
 | "It's interactive, so someone is watching — I can merge it" | `interactive` changes planning only. Step 8 is the same hard stop. |
 | "It's interactive, I'll confirm each step as I go" | The questions belong in Step 1. After that it runs like any other dispatch. |
+| "This ticket taught me something, that's an ADR" | Most tickets produce nothing durable. The bar is a decision that outlives the ticket, not a good day's work. |
+| "Nobody is watching, an ADR needs a human to agree" | Write it. Review rejects it — that is where the rarity is enforced, and it is one revert because the ADR is its own commit. |
+| "The ADR may as well ride the implementation commit" | Then rejecting it is surgery on a diff someone wants to keep. Its own commit, always. |
+| "My ADR number collides with another branch's" | Not your error. Number from the directory, say so, and let review renumber it. |

--- a/tests/test-csw-config.sh
+++ b/tests/test-csw-config.sh
@@ -15,6 +15,11 @@ assert_eq "$(cd "$repo" && "$BIN/csw-config" get ticketPrefix)" "" "default tick
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get trackerCommand)" "" "default trackerCommand is empty"
 assert_status 0 "trackerCommand is a known key, not an absent one" -- in_dir "$repo" "$BIN/csw-config" get trackerCommand
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get branchPattern)" "<type>/<ticket>-<slug>" "default branchPattern"
+# Empty means "this repo keeps no ADRs", and `/csw:work` never asks the question. The
+# exit-status assertion carries the same weight as trackerCommand's above: an absent key also
+# substitutes to the empty string, so assert_eq alone would pass with the default missing.
+assert_eq "$(cd "$repo" && "$BIN/csw-config" get adrDir)" "" "default adrDir is empty"
+assert_status 0 "adrDir is a known key, not an absent one" -- in_dir "$repo" "$BIN/csw-config" get adrDir
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get gates)" "[]" "default gates is an empty array"
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get batch.maxTickets)" "3" "default batch.maxTickets"
 assert_eq "$(cd "$repo" && "$BIN/csw-config" path)" "" "path is empty with no config file"
@@ -28,9 +33,11 @@ write_config "$repo" <<'JSON'
   "trackerCommand": "linear-cli todo --json",
   "validate": "just validate",
   "worktreeDir": ".claude/worktrees",
+  "adrDir": "docs/adr",
   "batch": { "maxTickets": 4 }
 }
 JSON
+assert_eq "$(cd "$repo" && "$BIN/csw-config" get adrDir)" "docs/adr" "override adrDir"
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get ticketPrefix)" "TRA" "override ticketPrefix"
 assert_eq "$(cd "$repo" && "$BIN/csw-config" get validate)" "just validate" "override validate"
 # trackerCommand replaces only the fetch, so a repo setting it keeps `tracker` too — the

--- a/tests/test-skills.sh
+++ b/tests/test-skills.sh
@@ -197,6 +197,44 @@ assert_contains "$work_red_flags" "modifier" \
 assert_contains "$work_red_flags" "interactive" \
   "work: red flags deny that interactive relaxes the hard stop"
 
+# --- work: the ADR pass, at the top of Step 8 ---
+#
+# Nothing in CSW used to ask whether a run produced a decision that outlives its ticket, so
+# every rejected approach and hard-won constraint died in a PR description nobody reads twice.
+# The pass lives at the top of Step 8, before the report, because Step 7 has already opened the
+# PR by then and the ADR rides it as a second commit.
+adr_start='^### Before the stop: did this produce a decision that outlives the ticket\?'
+adr_end='^\*\*Hold for review is a hard stop'
+# A repo that keeps no ADRs must never see any of this, which is what the empty default buys.
+assert_guards "$work" "$adr_start" "$adr_end" \
+  "csw-config get adrDir" "work: the ADR pass is gated on adrDir, so repos without ADRs never see it"
+# The rarity is the practice. An ADR per feature is the failure mode, and the bar has to sit in
+# the prompt text itself — asking the question is not the same as answering it yes.
+assert_guards "$work" "$adr_start" "$adr_end" \
+  "Most tickets produce nothing durable" \
+  "work: the ADR prompt carries its own bar, so the expected answer stays no"
+# Its own commit, so rejecting the ADR in review is one revert rather than surgery on a diff
+# somebody wants to keep. That is what makes always-write safe.
+assert_guards "$work" "$adr_start" "$adr_end" \
+  "docs: record ADR" "work: the ADR lands as its own commit, never folded into the implementation"
+# Gates are file-triggered, so a repo with a docs gate still gets it on the ADR path. Re-running
+# the whole validate would double every ADR's cost against code that did not change.
+assert_guards "$work" "$adr_start" "$adr_end" \
+  "csw-gates --files" "work: the ADR commit re-runs the gates for its path, not the full validate"
+# Two dispatches in one night both number from a directory neither can see the other writing.
+# Without this line a dispatch reads its own collision as a mistake and starts inventing
+# sequencing machinery for a problem review resolves in one rename.
+assert_guards "$work" "$adr_start" "$adr_end" \
+  "renumber" "work: an NNNN collision between concurrent dispatches is tolerated, not engineered around"
+# An ADR that merges unnoticed is the only way always-write goes wrong, so it has to be
+# announced where the human is already looking.
+assert_guards "$work" "$adr_start" "$adr_end" \
+  "proposed and revertible" "work: an ADR is announced as proposed, not as a decision already taken"
+assert_guards "$work" '^\*\*Hold for review is a hard stop' '^Then stop\.' \
+  "ADR" "work: Step 8's report names any ADR the run proposed"
+assert_contains "$work_red_flags" "ADR" \
+  "work: red flags catch an ADR written for a ticket that produced nothing durable"
+
 # --- prep: specs a ticket, touches nothing ---
 prep="$SKILLS/prep/SKILL.md"
 assert_contains "$(cat "$prep")" "csw-ticket normalize" "prep: normalises the ticket reference"
@@ -500,6 +538,20 @@ assert_contains "$batch_step1" "does not pre-check the shape" \
   "batch: shape validation stays in csw-batch-filter, which already names the bad field"
 assert_contains "$batch_red_flags" "trackerCommand" \
   "batch: a red flag catches empty trackerCommand output read as a quiet night"
+
+# --- batch: carrying an ADR back from a night's dispatch ---
+#
+# A subagent writes the ADR itself — solo and batch behave identically — but Step 7 states the
+# returned rows plus Step 2's groups are the whole input to the summary, so an ADR that is not
+# in the contract cannot reach the morning at all.
+assert_guards "$batch" '^### The report contract' '^## Step 6: When a ticket blocks or fails' \
+  '`adr`' "batch: the report contract carries the ADR a dispatch proposed"
+# Its own section rather than a note folded into `summary`: the failure mode being defended
+# against is an ADR merging unnoticed, and a section is what survives a skim.
+assert_contains "$batch_summary" "ADRs proposed" \
+  "batch: the morning summary surfaces the night's ADRs in a section of their own"
+assert_contains "$batch_red_flags" "ADR" \
+  "batch: red flags catch an ADR left buried in a summary line"
 
 # --- prep: recommends by default, asks only what a recommendation cannot settle ---
 # Measured over four tickets: prep asked 4-6 questions on each, and every question carrying a


### PR DESCRIPTION
Nothing in CSW ever asked whether a piece of work produced knowledge worth keeping. A rejected approach or a constraint discovered the hard way landed in a PR description nobody reads twice, and the batch loop made it worse — several unattended dispatches a night, none of them surfacing anything durable.

## What this adds

- **`bin/csw-config`** — new key `adrDir`, default `""`. Repos without ADRs see none of this.
- **`skills/work/SKILL.md`** — an ADR pass at the top of Step 8, before the report and gated on `adrDir` being non-empty. It asks once whether the run produced a decision that outlives its ticket, and carries its own bar: *most tickets produce nothing durable, and that is the expected answer*.
- **`skills/batch/SKILL.md`** — a sixth report-contract field, `adr`, and an **ADRs proposed** section in the morning summary.
- **`docs/configuration.md`**, **`examples/csw.json`**, **`.claude/csw.json`** — documented, exemplified, and turned on for this repo at `docs/adr`.
- **`tests/test-skills.sh`**, **`tests/test-csw-config.sh`** — 11 new skill assertions (region-scoped via `assert_guards` where the needle is not unique) plus the default and override checks.

## Decisions worth knowing about

Settled in the prep thread on #75, and they supersede parts of the description:

- **Both paths write.** A `csw:batch` subagent drafts the ADR exactly as a solo run does — this replaces "`/csw:batch` must never write an ADR unattended". A drafted file is concrete and cheap to reject; a "candidate" line in a summary is vague and evaporates, which is the failure this ticket exists to fix.
- **Review is the filter, so rejection has to be cheap.** The ADR is always its own commit (`docs: record ADR NNNN — <title>`), so rejecting it is one revert, and it is announced as proposed in Step 8's report, the PR body, and the morning summary.
- **The ADR commit re-runs `csw-gates --files` on its own path**, not the whole `validate`. No code changed between the two commits.
- **Numbering collisions are tolerated.** Two dispatches in one night can both claim the same `NNNN`; number from the directory at write time and let review renumber the second.
- No `docs/adr/` seed file and no first ADR here — the ticket asks for the mechanism, and Step 8 already handles an absent directory.

## Verification

`bash tests/run-tests.sh` green (177 passing in `test-skills.sh`), and the `bin/**` shellcheck gate green.

Closes #75